### PR TITLE
Update all classes to properly implement constructors and assignment …

### DIFF
--- a/DREAM3DReviewFilters/DBSCAN.h
+++ b/DREAM3DReviewFilters/DBSCAN.h
@@ -194,7 +194,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(bool, Mask)
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
 
-  DBSCAN(const DBSCAN&);         // Copy Constructor Not Implemented
+public:
+  DBSCAN(const DBSCAN&) = delete;            // Copy Constructor Not Implemented
+  DBSCAN(DBSCAN&&) = delete;                 // Move Constructor Not Implemented
   DBSCAN& operator=(const DBSCAN&) = delete; // Copy Assignment Not Implemented
   DBSCAN& operator=(DBSCAN&&) = delete;      // Move Assignment Not Implemented
 };

--- a/DREAM3DReviewFilters/FindNorm.h
+++ b/DREAM3DReviewFilters/FindNorm.h
@@ -173,7 +173,9 @@ private:
   DEFINE_IDATAARRAY_VARIABLE(InArray)
   DEFINE_DATAARRAY_VARIABLE(float, Norm)
 
-  FindNorm(const FindNorm&);       // Copy Constructor Not Implemented
+public:
+  FindNorm(const FindNorm&) = delete;            // Copy Constructor Not Implemented
+  FindNorm(FindNorm&&) = delete;                 // Move Constructor Not Implemented
   FindNorm& operator=(const FindNorm&) = delete; // Copy Assignment Not Implemented
   FindNorm& operator=(FindNorm&&) = delete;      // Move Assignment Not Implemented
 };

--- a/DREAM3DReviewFilters/KMeans.h
+++ b/DREAM3DReviewFilters/KMeans.h
@@ -195,7 +195,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
   DEFINE_DATAARRAY_VARIABLE(double, MeansArray)
 
-  KMeans(const KMeans&);         // Copy Constructor Not Implemented
+public:
+  KMeans(const KMeans&) = delete;            // Copy Constructor Not Implemented
+  KMeans(KMeans&&) = delete;                 // Move Constructor Not Implemented
   KMeans& operator=(const KMeans&) = delete; // Copy Assignment Not Implemented
   KMeans& operator=(KMeans&&) = delete;      // Move Assignment Not Implemented
 };

--- a/DREAM3DReviewFilters/KMedoids.h
+++ b/DREAM3DReviewFilters/KMedoids.h
@@ -195,7 +195,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(bool, Mask)
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
 
-  KMedoids(const KMedoids&);       // Copy Constructor Not Implemented
+public:
+  KMedoids(const KMedoids&) = delete;            // Copy Constructor Not Implemented
+  KMedoids(KMedoids&&) = delete;                 // Move Constructor Not Implemented
   KMedoids& operator=(const KMedoids&) = delete; // Copy Assignment Not Implemented
   KMedoids& operator=(KMedoids&&) = delete;      // Move Assignment Not Implemented
 };

--- a/DREAM3DReviewFilters/PottsModel.h
+++ b/DREAM3DReviewFilters/PottsModel.h
@@ -184,7 +184,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
   DEFINE_DATAARRAY_VARIABLE(bool, Mask)
 
-  PottsModel(const PottsModel&);     // Copy Constructor Not Implemented
+public:
+  PottsModel(const PottsModel&) = delete;            // Copy Constructor Not Implemented
+  PottsModel(PottsModel&&) = delete;                 // Move Constructor Not Implemented
   PottsModel& operator=(const PottsModel&) = delete; // Copy Assignment Not Implemented
   PottsModel& operator=(PottsModel&&) = delete;      // Move Assignment Not Implemented
 };

--- a/DREAM3DReviewFilters/Silhouette.h
+++ b/DREAM3DReviewFilters/Silhouette.h
@@ -186,7 +186,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
   DEFINE_DATAARRAY_VARIABLE(double, SilhouetteArray)
 
-  Silhouette(const Silhouette&);     // Copy Constructor Not Implemented
+public:
+  Silhouette(const Silhouette&) = delete;            // Copy Constructor Not Implemented
+  Silhouette(Silhouette&&) = delete;                 // Move Constructor Not Implemented
   Silhouette& operator=(const Silhouette&) = delete; // Copy Assignment Not Implemented
   Silhouette& operator=(Silhouette&&) = delete;      // Move Assignment Not Implemented
 };

--- a/DREAM3DReviewPlugin.h
+++ b/DREAM3DReviewPlugin.h
@@ -158,6 +158,6 @@ private:
   bool m_DidLoad;
 
   DREAM3DReviewPlugin(const DREAM3DReviewPlugin&) = delete; // Copy Constructor Not Implemented
-  void operator=(const DREAM3DReviewPlugin&);               // Move assignment Not Implemented
+  void operator=(const DREAM3DReviewPlugin&) = delete;      // Move assignment Not Implemented
 };
 


### PR DESCRIPTION
…operators.

Classes are updated to use C++11 standard '=delete' or '=default' for each of
the copy and move constructors and copy and move assignments.

Other misc formatting updates to any affected classes.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>