### PR TITLE
clang-tidy: selected modernize-* fixes and minor formatting changes

### DIFF
--- a/DREAM3DReviewFilters/ApplyTransformationToGeometry.cpp
+++ b/DREAM3DReviewFilters/ApplyTransformationToGeometry.cpp
@@ -61,7 +61,6 @@ ApplyTransformationToGeometry::ApplyTransformationToGeometry()
 : m_ComputedTransformationMatrix("", "", "TransformationMatrix")
 , m_GeometryToTransform("")
 , m_TransformationMatrixType(1)
-, m_TransformationMatrix(nullptr)
 {
   m_RotationAngle = 0.0f;
   m_RotationAxis.x = 0.0f;

--- a/DREAM3DReviewFilters/AverageEdgeFaceCellArrayToVertexArray.cpp
+++ b/DREAM3DReviewFilters/AverageEdgeFaceCellArrayToVertexArray.cpp
@@ -55,8 +55,6 @@
 AverageEdgeFaceCellArrayToVertexArray::AverageEdgeFaceCellArrayToVertexArray()
 : m_SelectedArrayPath("", "", "")
 , m_AverageVertexArrayPath(SIMPL::Defaults::VertexDataContainerName, SIMPL::Defaults::VertexAttributeMatrixName, "")
-, m_InCellArray(nullptr)
-, m_AverageVertexArray(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/AverageVertexArrayToEdgeFaceCellArray.cpp
+++ b/DREAM3DReviewFilters/AverageVertexArrayToEdgeFaceCellArray.cpp
@@ -58,8 +58,6 @@ AverageVertexArrayToEdgeFaceCellArray::AverageVertexArrayToEdgeFaceCellArray()
 : m_SelectedArrayPath("", "", "")
 , m_AverageCellArrayPath("", "", "")
 , m_WeightedAverage(false)
-, m_InVertexArray(nullptr)
-, m_AverageCellArray(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/DBSCAN.cpp
+++ b/DREAM3DReviewFilters/DBSCAN.cpp
@@ -62,9 +62,6 @@ DBSCAN::DBSCAN()
 , m_Epsilon(0.01f)
 , m_MinPnts(50)
 , m_DistanceMetric(0)
-, m_InData(nullptr)
-, m_Mask(nullptr)
-, m_FeatureIds(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/DREAM3DReviewFilters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -58,7 +58,6 @@ ExtractInternalSurfacesFromTriangleGeometry::ExtractInternalSurfacesFromTriangle
 : m_TriangleDataContainerName(SIMPL::Defaults::TriangleDataContainerName)
 , m_NodeTypesArrayPath(SIMPL::Defaults::TriangleDataContainerName, SIMPL::Defaults::VertexAttributeMatrixName, SIMPL::VertexData::SurfaceMeshNodeType)
 , m_InternalTrianglesName("InternalTrianglesDataContainer")
-, m_NodeTypes(nullptr)
 {
   initialize();
 }

--- a/DREAM3DReviewFilters/FindArrayStatistics.cpp
+++ b/DREAM3DReviewFilters/FindArrayStatistics.cpp
@@ -90,17 +90,6 @@ FindArrayStatistics::FindArrayStatistics()
 , m_StandardizedArrayName("Standardized")
 , m_SelectedArrayPath("", "", "")
 , m_FeatureIdsArrayPath("", "", "")
-, m_Length(nullptr)
-, m_Minimum(nullptr)
-, m_Maximum(nullptr)
-, m_Mean(nullptr)
-, m_Median(nullptr)
-, m_StandardDeviation(nullptr)
-, m_Summation(nullptr)
-, m_Standardized(nullptr)
-, m_InputArray(nullptr)
-, m_FeatureIds(nullptr)
-, m_Mask(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/FindElementCentroids.cpp
+++ b/DREAM3DReviewFilters/FindElementCentroids.cpp
@@ -56,7 +56,6 @@ FindElementCentroids::FindElementCentroids()
 , m_CreateVertexDataContainer(false)
 , m_NewDataContainerName(SIMPL::Defaults::VertexDataContainerName)
 , m_VertexAttributeMatrixName(SIMPL::Defaults::VertexAttributeMatrixName)
-, m_CellCentroidsArray(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/FindNorm.cpp
+++ b/DREAM3DReviewFilters/FindNorm.cpp
@@ -54,8 +54,6 @@ FindNorm::FindNorm()
 : m_SelectedArrayPath("", "", "")
 , m_NormArrayPath("", "", "Norm")
 , m_PSpace(2.0f)
-, m_InArray(nullptr)
-, m_Norm(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/KDistanceGraph.cpp
+++ b/DREAM3DReviewFilters/KDistanceGraph.cpp
@@ -58,7 +58,6 @@ KDistanceGraph::KDistanceGraph()
 , m_KDistanceArrayPath("", "", "KDistance")
 , m_MinDist(1)
 , m_DistanceMetric(0)
-, m_KDistanceArray(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/KMeans.cpp
+++ b/DREAM3DReviewFilters/KMeans.cpp
@@ -61,10 +61,6 @@ KMeans::KMeans()
 , m_InitClusters(1)
 , m_FeatureAttributeMatrixName("ClusterData")
 , m_DistanceMetric(0)
-, m_InData(nullptr)
-, m_Mask(nullptr)
-, m_FeatureIds(nullptr)
-, m_MeansArray(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/KMedoids.cpp
+++ b/DREAM3DReviewFilters/KMedoids.cpp
@@ -61,10 +61,6 @@ KMedoids::KMedoids()
 , m_FeatureAttributeMatrixName("ClusterData")
 , m_InitClusters(1)
 , m_DistanceMetric(0)
-, m_InData(nullptr)
-, m_MedoidsArray(nullptr)
-, m_Mask(nullptr)
-, m_FeatureIds(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/NormalizeArrays.cpp
+++ b/DREAM3DReviewFilters/NormalizeArrays.cpp
@@ -70,7 +70,6 @@ NormalizeArrays::NormalizeArrays()
 , m_UseMask(false)
 , m_MaskArrayPath("", "", "")
 , m_DefaultValue(0.0)
-, m_Mask(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/PointSampleTriangleGeometry.cpp
+++ b/DREAM3DReviewFilters/PointSampleTriangleGeometry.cpp
@@ -73,8 +73,6 @@ PointSampleTriangleGeometry::PointSampleTriangleGeometry()
 , m_UseMask(false)
 , m_MaskArrayPath("", "", "")
 , m_SelectedDataArrayPaths(QVector<DataArrayPath>())
-, m_TriangleAreas(nullptr)
-, m_Mask(nullptr)
 , m_NumSamples(0)
 {
 }

--- a/DREAM3DReviewFilters/PottsModel.cpp
+++ b/DREAM3DReviewFilters/PottsModel.cpp
@@ -364,8 +364,6 @@ PottsModel::PottsModel()
 , m_UseMask(false)
 , m_FeatureIdsArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::FeatureIds)
 , m_MaskArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::Mask)
-, m_FeatureIds(nullptr)
-, m_Mask(nullptr)
 {
   initialize();
 }

--- a/DREAM3DReviewFilters/PrincipalComponentAnalysis.cpp
+++ b/DREAM3DReviewFilters/PrincipalComponentAnalysis.cpp
@@ -65,8 +65,6 @@ PrincipalComponentAnalysis::PrincipalComponentAnalysis()
 , m_ProjectDataSpace(false)
 , m_NumberOfDimensionsForProjection(0)
 , m_ProjectedDataSpaceArrayPath("", "", "ProjectedDataSpace")
-, m_PCEigenvalues(nullptr)
-, m_PCEigenvectors(nullptr)
 {
 }
 

--- a/DREAM3DReviewFilters/RobustAutomaticThreshold.cpp
+++ b/DREAM3DReviewFilters/RobustAutomaticThreshold.cpp
@@ -52,9 +52,6 @@ RobustAutomaticThreshold::RobustAutomaticThreshold()
 : m_InputArrayPath("", "", "")
 , m_FeatureIdsArrayPath("", "", "Mask")
 , m_GradientMagnitudeArrayPath("", "", "")
-, m_InputArray(nullptr)
-, m_GradientMagnitude(nullptr)
-, m_FeatureIds(nullptr)
 {
   initialize();
 }

--- a/DREAM3DReviewFilters/Silhouette.cpp
+++ b/DREAM3DReviewFilters/Silhouette.cpp
@@ -61,10 +61,6 @@ Silhouette::Silhouette()
 , m_FeatureIdsArrayPath("", "", "ClusterIds")
 , m_SilhouetteArrayPath("", "", "Silhouette")
 , m_DistanceMetric(0)
-, m_InData(nullptr)
-, m_Mask(nullptr)
-, m_FeatureIds(nullptr)
-, m_SilhouetteArray(nullptr)
 {
 }
 


### PR DESCRIPTION
modernize-use-nullptr
modernize-deprecated-headers
modernize-shrink-to-fit
modernize-use-bool-literals
modernize-use-default-member-init
modernize-use-equals-default
modernize-use-equals-delete
modernize-use-override

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>