### PR TITLE
Fix bugs in InterpolatePointCloudToRegularGrid and MapPointCloudToRegularGrid, Update QMMeltPoolImporter

### DIFF
--- a/DREAM3DReviewConstants.h
+++ b/DREAM3DReviewConstants.h
@@ -2,6 +2,11 @@
 
 #include <QtCore/QString>
 
+/** @brief This macro is used to shorten the code needed to go from std::string to QString. Helpful in other codes that use
+ * QString instead of std::string
+ */
+#define S2Q(var) QString::fromStdString((var))
+
 /**
  * @brief This namespace is used to define some Constants for the plugin itself.
  */

--- a/DREAM3DReviewFilters/AdaptiveAlignmentFeature.cpp
+++ b/DREAM3DReviewFilters/AdaptiveAlignmentFeature.cpp
@@ -479,8 +479,6 @@ float AdaptiveAlignmentFeature::compute_error2(uint64_t iter, uint64_t index, st
 // -----------------------------------------------------------------------------
 void AdaptiveAlignmentFeature::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/AdaptiveAlignmentMutualInformation.cpp
+++ b/DREAM3DReviewFilters/AdaptiveAlignmentMutualInformation.cpp
@@ -809,8 +809,6 @@ void AdaptiveAlignmentMutualInformation::form_features_sections()
 // -----------------------------------------------------------------------------
 void AdaptiveAlignmentMutualInformation::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/ApplyTransformationToGeometry.cpp
+++ b/DREAM3DReviewFilters/ApplyTransformationToGeometry.cpp
@@ -403,8 +403,6 @@ void ApplyTransformationToGeometry::applyTransformation()
 // -----------------------------------------------------------------------------
 void ApplyTransformationToGeometry::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/AverageEdgeFaceCellArrayToVertexArray.cpp
+++ b/DREAM3DReviewFilters/AverageEdgeFaceCellArrayToVertexArray.cpp
@@ -290,8 +290,6 @@ void AverageEdgeFaceCellArrayToVertexArray::dataCheck()
 // -----------------------------------------------------------------------------
 void AverageEdgeFaceCellArrayToVertexArray::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/AverageVertexArrayToEdgeFaceCellArray.cpp
+++ b/DREAM3DReviewFilters/AverageVertexArrayToEdgeFaceCellArray.cpp
@@ -349,8 +349,6 @@ void AverageVertexArrayToEdgeFaceCellArray::dataCheck()
 // -----------------------------------------------------------------------------
 void AverageVertexArrayToEdgeFaceCellArray::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/ComputeUmeyamaTransform.cpp
+++ b/DREAM3DReviewFilters/ComputeUmeyamaTransform.cpp
@@ -220,8 +220,6 @@ void ComputeUmeyamaTransform::dataCheck()
 // -----------------------------------------------------------------------------
 void ComputeUmeyamaTransform::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/DBSCAN.cpp
+++ b/DREAM3DReviewFilters/DBSCAN.cpp
@@ -263,8 +263,6 @@ void DBSCAN::dataCheck()
 // -----------------------------------------------------------------------------
 void DBSCAN::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/DelaunayTriangulation.cpp
+++ b/DREAM3DReviewFilters/DelaunayTriangulation.cpp
@@ -267,8 +267,6 @@ void DelaunayTriangulation::dataCheck()
 // -----------------------------------------------------------------------------
 void DelaunayTriangulation::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/DiscretizeDDDomain.cpp
+++ b/DREAM3DReviewFilters/DiscretizeDDDomain.cpp
@@ -129,9 +129,10 @@ void DiscretizeDDDomain::initialize()
 // -----------------------------------------------------------------------------
 void DiscretizeDDDomain::dataCheck()
 {
-  DataArrayPath tempPath;
+
   clearErrorCode();
   clearWarningCode();
+  DataArrayPath tempPath;
 
   // First sanity check the inputs and output names. All must be filled in
 

--- a/DREAM3DReviewFilters/DownsampleVertexGeometry.cpp
+++ b/DREAM3DReviewFilters/DownsampleVertexGeometry.cpp
@@ -582,8 +582,6 @@ void DownsampleVertexGeometry::gridDownsample()
 // -----------------------------------------------------------------------------
 void DownsampleVertexGeometry::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/ExtractTripleLinesFromTriangleGeometry.cpp
+++ b/DREAM3DReviewFilters/ExtractTripleLinesFromTriangleGeometry.cpp
@@ -126,7 +126,7 @@ void ExtractTripleLinesFromTriangleGeometry::setupFilterParameters()
 void ExtractTripleLinesFromTriangleGeometry::dataCheck()
 {
   clearErrorCode();
-
+  clearWarningCode();
   QVector<IDataArray::Pointer> dataArrays;
 
   TriangleGeom::Pointer triangle = getDataContainerArray()->getPrereqGeometryFromDataContainer<TriangleGeom>(this, getNodeTypesArrayPath().getDataContainerName());

--- a/DREAM3DReviewFilters/FFTHDFWriterFilter.cpp
+++ b/DREAM3DReviewFilters/FFTHDFWriterFilter.cpp
@@ -187,8 +187,6 @@ void FFTHDFWriterFilter::dataCheck()
 // -----------------------------------------------------------------------------
 void FFTHDFWriterFilter::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/FindArrayStatistics.cpp
+++ b/DREAM3DReviewFilters/FindArrayStatistics.cpp
@@ -711,8 +711,6 @@ void findStatistics(IDataArray::Pointer source, Int32ArrayType::Pointer featureI
 // -----------------------------------------------------------------------------
 void FindArrayStatistics::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/FindCSLBoundaries.cpp
+++ b/DREAM3DReviewFilters/FindCSLBoundaries.cpp
@@ -322,9 +322,9 @@ void FindCSLBoundaries::dataCheckVoxel()
 // -----------------------------------------------------------------------------
 void FindCSLBoundaries::dataCheckSurfaceMesh()
 {
-  DataArrayPath tempPath;
   clearErrorCode();
   clearWarningCode();
+  DataArrayPath tempPath;
 
   getDataContainerArray()->getPrereqGeometryFromDataContainer<TriangleGeom>(this, getSurfaceMeshFaceLabelsArrayPath().getDataContainerName());
 
@@ -360,6 +360,9 @@ void FindCSLBoundaries::dataCheckSurfaceMesh()
 // -----------------------------------------------------------------------------
 void FindCSLBoundaries::dataCheck()
 {
+  clearErrorCode();
+  clearWarningCode();
+
   dataCheckVoxel();
   dataCheckSurfaceMesh();
 }

--- a/DREAM3DReviewFilters/FindElementCentroids.cpp
+++ b/DREAM3DReviewFilters/FindElementCentroids.cpp
@@ -216,8 +216,6 @@ void FindElementCentroids::dataCheck()
 // -----------------------------------------------------------------------------
 void FindElementCentroids::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/FindLayerStatistics.cpp
+++ b/DREAM3DReviewFilters/FindLayerStatistics.cpp
@@ -325,8 +325,6 @@ void FindLayerStatistics::dataCheck()
 // -----------------------------------------------------------------------------
 void FindLayerStatistics::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/FindNeighborListStatistics.cpp
+++ b/DREAM3DReviewFilters/FindNeighborListStatistics.cpp
@@ -280,8 +280,6 @@ void findStatistics(AbstractFilter* filter, IDataArray::Pointer source, bool len
 // -----------------------------------------------------------------------------
 void FindNeighborListStatistics::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/FindNorm.cpp
+++ b/DREAM3DReviewFilters/FindNorm.cpp
@@ -170,8 +170,6 @@ void findPthNorm(IDataArray::Pointer inDataPtr, const FloatArrayType::Pointer& n
 // -----------------------------------------------------------------------------
 void FindNorm::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/FindVertexToTriangleDistances.cpp
+++ b/DREAM3DReviewFilters/FindVertexToTriangleDistances.cpp
@@ -154,7 +154,7 @@ void FindVertexToTriangleDistances::setupFilterParameters()
 void FindVertexToTriangleDistances::dataCheck()
 {
   clearErrorCode();
-
+  clearWarningCode();
   getDataContainerArray()->getPrereqGeometryFromDataContainer<VertexGeom>(this, getVertexDataContainer());
   getDataContainerArray()->getPrereqGeometryFromDataContainer<TriangleGeom>(this, getTriangleDataContainer());
 

--- a/DREAM3DReviewFilters/IdentifyDislocationSegments.cpp
+++ b/DREAM3DReviewFilters/IdentifyDislocationSegments.cpp
@@ -148,10 +148,11 @@ void IdentifyDislocationSegments::initialize()
 // -----------------------------------------------------------------------------
 void IdentifyDislocationSegments::dataCheck()
 {
-  DataArrayPath tempPath;
+
   clearErrorCode();
   clearWarningCode();
 
+  DataArrayPath tempPath;
   // Next check the existing DataContainer/AttributeMatrix
   DataContainer::Pointer m = getDataContainerArray()->getPrereqDataContainer(this, getBurgersVectorsArrayPath().getDataContainerName());
   if(getErrorCode() < 0)

--- a/DREAM3DReviewFilters/ImportPrintRiteHDF5File.cpp
+++ b/DREAM3DReviewFilters/ImportPrintRiteHDF5File.cpp
@@ -237,6 +237,9 @@ void ImportPrintRiteHDF5File::readArray(const DataArrayPath& path, const hid_t& 
 // -----------------------------------------------------------------------------
 void ImportPrintRiteHDF5File::dataCheck()
 {
+  clearErrorCode();
+  clearWarningCode();
+
   m_SliceGroups.clear();
   m_SortedSliceGroups.clear();
   m_HFDataSetNames.clear();
@@ -248,8 +251,6 @@ void ImportPrintRiteHDF5File::dataCheck()
   m_NumLFVertsPerSlice.clear();
   m_CumulativeNumHFVerts.clear();
 
-  clearErrorCode();
-  clearWarningCode();
   int32_t err = -1;
 
   QFileInfo fi(getInputFile());
@@ -477,8 +478,6 @@ void ImportPrintRiteHDF5File::dataCheck()
 // -----------------------------------------------------------------------------
 void ImportPrintRiteHDF5File::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/ImportPrintRiteTDMSFiles.cpp
+++ b/DREAM3DReviewFilters/ImportPrintRiteTDMSFiles.cpp
@@ -169,6 +169,7 @@ void ImportPrintRiteTDMSFiles::setupFilterParameters()
 void ImportPrintRiteTDMSFiles::dataCheck()
 {
   clearErrorCode();
+  clearWarningCode();
 
   if(getLayerThickness() <= 0.0f)
   {

--- a/DREAM3DReviewFilters/ImportQMMeltpoolH5File.cpp
+++ b/DREAM3DReviewFilters/ImportQMMeltpoolH5File.cpp
@@ -123,48 +123,12 @@ std::string make_list_string(const Container& items)
 
   return ss.str();
 }
-} // namespace
 
-struct ImportQMMeltpoolH5File::Cache
-{
-  fs::file_time_type lastModified;
-  std::string filePath;
-  IntVec2Type sliceRange;
-
-  std::vector<int64_t> missingIndices;
-  std::vector<int64_t> layerThicknesses;
-  std::vector<int64_t> numElements;
-
-  void flush()
-  {
-    filePath = "";
-    sliceRange = {};
-
-    missingIndices.clear();
-
-    layerThicknesses.clear();
-    numElements.clear();
-  }
-};
-
-// -----------------------------------------------------------------------------
-ImportQMMeltpoolH5File::ImportQMMeltpoolH5File()
-{
-  initialize();
-}
-
-// -----------------------------------------------------------------------------
-ImportQMMeltpoolH5File::~ImportQMMeltpoolH5File() = default;
-
-// -----------------------------------------------------------------------------
-void ImportQMMeltpoolH5File::initialize()
-{
-  clearErrorCode();
-  clearWarningCode();
-  setCancel(false);
-}
-
-// -----------------------------------------------------------------------------
+/**
+ * @brief Returns Error Code and Error Message if the checks do not pass
+ * @param filePath The file path to check
+ * @return Error Code (<0 is bad) and Error Message if something didn't pass
+ */
 std::pair<int32_t, std::string> checkFile(const std::string& filePath)
 {
   if(filePath.empty())
@@ -191,6 +155,36 @@ std::pair<int32_t, std::string> checkFile(const std::string& filePath)
 
   return {0, ""};
 }
+
+} // namespace
+
+struct ImportQMMeltpoolH5File::Cache
+{
+  fs::file_time_type lastModified;
+  std::string filePath;
+  IntVec2Type sliceRange;
+
+  std::vector<int64_t> missingIndices;
+  std::vector<int64_t> layerThicknesses;
+  std::vector<int64_t> numElements;
+
+  void flush()
+  {
+    filePath = "";
+    sliceRange = {};
+
+    missingIndices.clear();
+
+    layerThicknesses.clear();
+    numElements.clear();
+  }
+};
+
+// -----------------------------------------------------------------------------
+ImportQMMeltpoolH5File::ImportQMMeltpoolH5File() = default;
+
+// -----------------------------------------------------------------------------
+ImportQMMeltpoolH5File::~ImportQMMeltpoolH5File() = default;
 
 // -----------------------------------------------------------------------------
 void ImportQMMeltpoolH5File::createUpdateCacheEntries()
@@ -253,6 +247,7 @@ void ImportQMMeltpoolH5File::dataCheck()
 {
   clearErrorCode();
   clearWarningCode();
+  setCancel(false);
 
   auto dca = getDataContainerArray();
 
@@ -265,7 +260,7 @@ void ImportQMMeltpoolH5File::dataCheck()
   // Check all of the files
   for(const auto& inputFile : m_InputFiles)
   {
-    std::pair<int32_t, std::string> result = checkFile(inputFile);
+    std::pair<int32_t, std::string> result = ::checkFile(inputFile);
     if(result.first < 0)
     {
       setErrorCondition(result.first, S2Q(result.second));
@@ -297,7 +292,6 @@ void ImportQMMeltpoolH5File::dataCheck()
 // -----------------------------------------------------------------------------
 void ImportQMMeltpoolH5File::execute()
 {
-  initialize();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/ImportQMMeltpoolH5File.cpp
+++ b/DREAM3DReviewFilters/ImportQMMeltpoolH5File.cpp
@@ -48,9 +48,11 @@
 #include "SIMPLib/DataContainers/DataContainer.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 #include "SIMPLib/FilterParameters/DataContainerCreationFilterParameter.h"
+#include "SIMPLib/FilterParameters/FileListInfoFilterParameter.h"
 #include "SIMPLib/FilterParameters/FloatFilterParameter.h"
 #include "SIMPLib/FilterParameters/InputFileFilterParameter.h"
 #include "SIMPLib/FilterParameters/IntVec2FilterParameter.h"
+#include "SIMPLib/FilterParameters/MultiInputFileFilterParameter.h"
 #include "SIMPLib/FilterParameters/PreflightUpdatedValueFilterParameter.h"
 #include "SIMPLib/FilterParameters/StringFilterParameter.h"
 #include "SIMPLib/Geometry/VertexGeom.h"
@@ -125,19 +127,19 @@ std::string make_list_string(const Container& items)
 
 struct ImportQMMeltpoolH5File::Cache
 {
-  QDateTime lastModified;
-  QString filePath;
+  // QDateTime lastModified;
+  fs::file_time_type lastModified;
+  std::string filePath;
   IntVec2Type sliceRange;
 
   std::vector<int64_t> missingIndices;
-
   std::vector<int64_t> layerThicknesses;
   std::vector<int64_t> numElements;
 
   void flush()
   {
     filePath = "";
-    lastModified = QDateTime();
+    // lastModified = QDateTime();
     sliceRange = {};
 
     missingIndices.clear();
@@ -149,7 +151,6 @@ struct ImportQMMeltpoolH5File::Cache
 
 // -----------------------------------------------------------------------------
 ImportQMMeltpoolH5File::ImportQMMeltpoolH5File()
-: m_Cache(std::make_unique<Cache>())
 {
   initialize();
 }
@@ -166,15 +167,86 @@ void ImportQMMeltpoolH5File::initialize()
 }
 
 // -----------------------------------------------------------------------------
+std::pair<int32_t, std::string> checkFile(const std::string& filePath)
+{
+  if(filePath.empty())
+  {
+    return {k_FilePathEmptyError, "The HDF5 file path is empty.  Please select an HDF5 file."};
+  }
+
+  fs::path ifPath = fs::path(filePath);
+  // Make sure the file exists on disk
+  if(!fs::exists(ifPath))
+  {
+    std::stringstream ss;
+    ss << "Input File does not exist at '" << ifPath.string() << "'\n";
+    return {k_FileDoesNotExist, ss.str()};
+  }
+  fs::path ext = ifPath.extension();
+
+  if(ext != ".h5" && ext != ".hdf5")
+  {
+    std::stringstream ss;
+    ss << "The selected file '%1' is not an HDF5 file." << filePath;
+    return {k_FileTypeError, ss.str()};
+  }
+
+  return {0, ""};
+}
+
+// -----------------------------------------------------------------------------
+void ImportQMMeltpoolH5File::createUpdateCacheEntries()
+{
+  // Check all of the files
+  if(m_Caches.size() != m_InputFiles.size())
+  {
+    m_Caches.resize(m_InputFiles.size());
+  }
+
+  for(size_t i = 0; i < m_InputFiles.size(); i++)
+  {
+    std::string& inputFile = m_InputFiles.at(i);
+    Cache& cache = m_Caches.at(i);
+
+    fs::path ifPath = fs::path(inputFile);
+    auto timeStamp = fs::last_write_time(ifPath);
+
+    if(!(cache.filePath == inputFile && timeStamp == cache.lastModified && cache.sliceRange == m_SliceRange))
+    {
+      // Read from the file and cache all of the slices and slice data
+      // Will need to read the number of tuples in the X-Axis and store for each slice
+      // User might be able to control which of the 3 data sets that they want to import
+      // Building up the Data Structure with this information will allow the Geometry to be fully specified
+      cache.flush();
+      cache.filePath = inputFile;
+      generateCache(cache);
+      if(cache.missingIndices.empty())
+      {
+        cache.filePath = inputFile;
+        cache.lastModified = timeStamp;
+        cache.sliceRange = m_SliceRange;
+      }
+    }
+
+    if(!cache.missingIndices.empty())
+    {
+      std::string index_list = make_list_string(cache.missingIndices);
+      setErrorCondition(k_MissingSlicesError, QString("Slices %1 in the given range are missing from the file").arg(QString::fromStdString(index_list)));
+      return;
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
 void ImportQMMeltpoolH5File::setupFilterParameters()
 {
   FilterParameterVectorType parameters;
-  parameters.push_back(SIMPL_NEW_INPUT_FILE_FP("HDF5 File Path", HDF5FilePath, FilterParameter::Parameter, ImportQMMeltpoolH5File, "*.h5 *.hdf5"));
+  parameters.push_back(SIMPL_NEW_MULTI_INPUT_FILE_FP("Input File(s)", InputFiles, FilterParameter::Parameter, ImportQMMeltpoolH5File, "*.h5 *.hdf5"));
+  parameters.push_back(SIMPL_NEW_PREFLIGHTUPDATEDVALUE_FP("Possible Slice Indices", PossibleIndices, FilterParameter::Parameter, ImportQMMeltpoolH5File));
   parameters.push_back(SIMPL_NEW_INT_VEC2_FP("Slice Index Start/End [Inclusive]", SliceRange, FilterParameter::Parameter, ImportQMMeltpoolH5File));
   parameters.push_back(SIMPL_NEW_DC_CREATION_FP("Data Container Name", DataContainerPath, FilterParameter::Parameter, ImportQMMeltpoolH5File));
   parameters.push_back(SIMPL_NEW_STRING_FP("Vertex Attribute Matrix Name", VertexAttributeMatrixName, FilterParameter::Parameter, ImportQMMeltpoolH5File));
   parameters.push_back(SIMPL_NEW_FLOAT_FP("Power", Power, FilterParameter::Parameter, ImportQMMeltpoolH5File));
-  parameters.push_back(SIMPL_NEW_PREFLIGHTUPDATEDVALUE_FP("Possible Indices", PossibleIndices, FilterParameter::Parameter, ImportQMMeltpoolH5File));
   setFilterParameters(parameters);
 }
 
@@ -192,31 +264,17 @@ void ImportQMMeltpoolH5File::dataCheck()
     return;
   }
 
-  if(m_HDF5FilePath.isEmpty())
+  // Check all of the files
+  for(const auto& inputFile : m_InputFiles)
   {
-    QString ss = "The HDF5 file path is empty.  Please select an HDF5 file.";
-    setErrorCondition(k_FilePathEmptyError, ss);
-    return;
-  }
-  fs::path ifPath = fs::path(getHDF5FilePath().toStdString());
-
-  // Make sure the file exists on disk
-  if(!fs::exists(ifPath))
-  {
-    std::stringstream ss;
-    ss << "Input File does not exist at '" << ifPath.string() << "'\n";
-    setErrorCondition(k_FileDoesNotExist, QString::fromStdString(ss.str()));
-    return;
-  }
-  fs::path ext = ifPath.extension();
-
-  if(ext != ".h5" && ext != ".hdf5")
-  {
-    QString ss = tr("The selected file '%1' is not an HDF5 file.").arg(getHDF5FilePath());
-    setErrorCondition(k_FileTypeError, ss);
-    return;
+    std::pair<int32_t, std::string> result = checkFile(inputFile);
+    if(result.first < 0)
+    {
+      setErrorCondition(result.first, S2Q(result.second));
+    }
   }
 
+  // Check the slice range
   if(m_SliceRange[0] < 0 || m_SliceRange[1] < 0)
   {
     setErrorCondition(k_StartEndError, "Start/end must be 0 or positive");
@@ -234,33 +292,7 @@ void ImportQMMeltpoolH5File::dataCheck()
     setErrorCondition(k_DataContainerError, QString("DataContainer \"%1\" already exists").arg(m_DataContainerPath.getDataContainerName()));
     return;
   }
-
-  QFileInfo fi(m_HDF5FilePath);
-  QDateTime timeStamp = fi.lastModified();
-
-  if(!(m_Cache->filePath == m_HDF5FilePath && m_Cache->lastModified.isValid() && timeStamp == m_Cache->lastModified && m_Cache->sliceRange == m_SliceRange))
-  {
-    // Read from the file and cache all of the slices and slice data
-    // Will need to read the number of tuples in the X-Axis and store for each slice
-    // User might be able to control which of the 3 data sets that they want to import
-    // Building up the Data Structure with this information will allow the Geometry to be fully specified
-    m_Cache->flush();
-    generateCache();
-    if(m_Cache->missingIndices.empty())
-    {
-      m_Cache->filePath = m_HDF5FilePath;
-      m_Cache->lastModified = timeStamp;
-      m_Cache->sliceRange = m_SliceRange;
-    }
-  }
-
-  if(!m_Cache->missingIndices.empty())
-  {
-    std::string index_list = make_list_string(m_Cache->missingIndices);
-    setErrorCondition(k_MissingSlicesError, QString("Slices %1 in the given range are missing from the file").arg(QString::fromStdString(index_list)));
-    return;
-  }
-
+  createUpdateCacheEntries();
   generateDataStructure();
 }
 
@@ -283,9 +315,11 @@ void ImportQMMeltpoolH5File::execute()
 }
 
 // -----------------------------------------------------------------------------
-void ImportQMMeltpoolH5File::generateCache()
+void ImportQMMeltpoolH5File::generateCache(ImportQMMeltpoolH5File::Cache& cache)
 {
-  hid_t fileId = H5Utilities::openFile(getHDF5FilePath().toStdString(), true);
+  const std::string& filePath = cache.filePath;
+
+  hid_t fileId = H5Utilities::openFile(filePath, true);
   if(fileId < 0)
   {
     setErrorCondition(k_HDF5FileOpenError, "Error opening HDF5 file.");
@@ -350,10 +384,9 @@ void ImportQMMeltpoolH5File::generateCache()
     }
   }
 
-  m_Cache->missingIndices = std::move(missingIndices);
-
-  m_Cache->layerThicknesses = std::move(layerThicknesses);
-  m_Cache->numElements = std::move(numElements);
+  cache.missingIndices = std::move(missingIndices);
+  cache.layerThicknesses = std::move(layerThicknesses);
+  cache.numElements = std::move(numElements);
 }
 
 // -----------------------------------------------------------------------------
@@ -364,8 +397,18 @@ void ImportQMMeltpoolH5File::generateDataStructure()
   DataContainer::Pointer dc = DataContainer::New(getDataContainerPath());
   dca->addOrReplaceDataContainer(dc);
 
+  // Compute the total number of vertices
+  size_t numVerts = 0;
+  for(const auto& cache : m_Caches)
+  {
+    numVerts += std::accumulate(cache.numElements.cbegin(), cache.numElements.cend(), 0ULL);
+  }
+
+  if(!getInPreflight())
+  {
+    notifyStatusMessage("Allocating Vertex Geometry");
+  }
   // Create the Geometry
-  size_t numVerts = std::accumulate(m_Cache->numElements.cbegin(), m_Cache->numElements.cend(), 0ULL);
   VertexGeom::Pointer vertGeom = VertexGeom::CreateGeometry(numVerts, "Vertex Geometry", !getInPreflight());
   vertGeom->setUnits(IGeometry::LengthUnit::Micrometer);
   dc->setGeometry(vertGeom);
@@ -376,23 +419,46 @@ void ImportQMMeltpoolH5File::generateDataStructure()
 
   // Create the various Vertex Data Arrays
   // The list is hard coded for now
-
+  if(!getInPreflight())
+  {
+    notifyStatusMessage("Allocating " + QString::fromStdString(k_Area) + " Array");
+  }
   Int16ArrayType::Pointer areaData = Int16ArrayType::CreateArray(numVerts, k_Area, !getInPreflight());
   vertAm->addOrReplaceAttributeArray(areaData);
 
+  if(!getInPreflight())
+  {
+    notifyStatusMessage("Allocating " + QString::fromStdString(k_Intensity) + " Array");
+  }
   Int16ArrayType::Pointer intensityData = Int16ArrayType::CreateArray(numVerts, k_Intensity, !getInPreflight());
   vertAm->addOrReplaceAttributeArray(intensityData);
 
+  if(!getInPreflight())
+  {
+    notifyStatusMessage("Allocating " + QString::fromStdString(k_LaserTTL) + " Array");
+  }
   UInt8ArrayType::Pointer laserTtlData = UInt8ArrayType::CreateArray(numVerts, k_LaserTTL, !getInPreflight());
   vertAm->addOrReplaceAttributeArray(laserTtlData);
 
+  if(!getInPreflight())
+  {
+    notifyStatusMessage("Allocating " + QString::fromStdString(k_Slice) + " Array");
+  }
   // This is an extra data set that we are going to add to aid in visualization
   Int16ArrayType::Pointer sliceData = Int16ArrayType::CreateArray(numVerts, k_Slice, !getInPreflight());
   vertAm->addOrReplaceAttributeArray(sliceData);
 
+  if(!getInPreflight())
+  {
+    notifyStatusMessage("Allocating " + k_Time + " Array");
+  }
   DoubleArrayType::Pointer timeData = DoubleArrayType::CreateArray(numVerts, k_Time, !getInPreflight());
   vertAm->addOrReplaceAttributeArray(timeData);
 
+  if(!getInPreflight())
+  {
+    notifyStatusMessage("Allocating " + k_Power + " Array");
+  }
   FloatArrayType::Pointer powerData = FloatArrayType::CreateArray(numVerts, k_Power, !getInPreflight());
   vertAm->addOrReplaceAttributeArray(powerData);
 
@@ -405,6 +471,7 @@ void ImportQMMeltpoolH5File::generateDataStructure()
 // -----------------------------------------------------------------------------
 void ImportQMMeltpoolH5File::readDataFromFile()
 {
+
   DataContainer::Pointer dc = getDataContainerArray()->getDataContainer(getDataContainerPath());
   if(dc == nullptr)
   {
@@ -428,195 +495,207 @@ void ImportQMMeltpoolH5File::readDataFromFile()
     return;
   }
 
-  hid_t fileId = H5Utilities::openFile(getHDF5FilePath().toStdString(), true);
-  if(fileId < 0)
-  {
-    setErrorCondition(k_HDF5FileOpenError, "Error opening HDF5 file.");
-    return;
-  }
-  H5ScopedFileSentinel sentinel(fileId, true);
-
-  // Find the min/max tuple count of all the slices
-  auto max = std::max_element(m_Cache->numElements.cbegin(), m_Cache->numElements.cend());
-
-  if(max == m_Cache->numElements.cend())
-  {
-    setErrorCondition(k_NumElementsError, "Couldn't get number of elements");
-    return;
-  }
-
-  // Create vectors large enough to hold the largest slice data. Cuts down on memory allocations
-  std::vector<float> xCoord(*max);
-  std::vector<float> yCoord(*max);
-
   size_t offset = 0;
-
-  auto areaData = vertAM->getAttributeArrayAs<Int16ArrayType>(QString::fromStdString(k_Area));
-  if(areaData == nullptr)
+  int32_t fileNum = 0;
+  for(const auto& cache : m_Caches)
   {
-    setErrorCondition(k_DataStructureError, "Failed to acquire Area DataArray");
-    return;
-  }
-  auto intensityData = vertAM->getAttributeArrayAs<Int16ArrayType>(QString::fromStdString(k_Intensity));
-  if(intensityData == nullptr)
-  {
-    setErrorCondition(k_DataStructureError, "Failed to acquire Intensity DataArray");
-    return;
-  }
-  auto laserTtlData = vertAM->getAttributeArrayAs<UInt8ArrayType>(QString::fromStdString(k_LaserTTL));
-  if(laserTtlData == nullptr)
-  {
-    setErrorCondition(k_DataStructureError, "Failed to acquire LaserTTL DataArray");
-    return;
-  }
-  auto sliceData = vertAM->getAttributeArrayAs<Int16ArrayType>(QString::fromStdString(k_Slice));
-  if(sliceData == nullptr)
-  {
-    setErrorCondition(k_DataStructureError, "Failed to acquire Slice DataArray");
-    return;
-  }
-  auto timeData = vertAM->getAttributeArrayAs<DoubleArrayType>(k_Time);
-  if(timeData == nullptr)
-  {
-    setErrorCondition(k_DataStructureError, "Failed to acquire Time DataArray");
-    return;
-  }
-
-  float cummulativeLayerThickness = 0.0F; // Assumes microns? Maybe?
-  double currentTime = 0.0;
-  QDateTime initialTime;
-
-  hid_t dataGroup = H5Utilities::createGroup(fileId, k_TDMSData);
-  if(dataGroup < 0)
-  {
-    setErrorCondition(k_HDF5FileOpenError, "Failed to open HDF5 file");
-    return;
-  }
-  H5ScopedGroupSentinel dataGroupSentinel(dataGroup, true);
-
-  {
-    hid_t sliceGroup = H5Utilities::createGroup(dataGroup, std::to_string(m_SliceRange[0]));
-    if(sliceGroup < 0)
+    if(getCancel())
     {
-      setErrorCondition(k_HDF5GroupOpenError, "Failed to open HDF5 slice group");
       return;
     }
-    H5ScopedGroupSentinel sliceGroupSentinel(sliceGroup, true);
+    QString msg;
+    QTextStream out(&msg);
+    out << fileNum++ << "/" << m_Caches.size() << ": Reading File: " + QString::fromStdString(cache.filePath);
+    notifyStatusMessage(msg.toLatin1().data());
 
-    std::string partStartTimeString;
-    herr_t err = H5Lite::readStringAttribute(sliceGroup, k_PartStartTime, partStartTimeString);
-    if(err < 0)
+    hid_t fileId = H5Utilities::openFile(cache.filePath, true);
+    if(fileId < 0)
     {
-      setErrorCondition(k_HDF5AttributeError, "Failed to open HDF5 attribute PartStartTime");
+      setErrorCondition(k_HDF5FileOpenError, "Error opening HDF5 file.");
+      return;
+    }
+    H5ScopedFileSentinel sentinel(fileId, true);
+
+    // Find the min/max tuple count of all the slices
+    auto max = std::max_element(cache.numElements.cbegin(), cache.numElements.cend());
+
+    if(max == cache.numElements.cend())
+    {
+      setErrorCondition(k_NumElementsError, "Couldn't get number of elements");
       return;
     }
 
-    initialTime = QDateTime::fromString(QString::fromStdString(partStartTimeString), Qt::DateFormat::ISODateWithMs);
-  }
+    // Create vectors large enough to hold the largest slice data. Cuts down on memory allocations
+    std::vector<float> xCoord(*max);
+    std::vector<float> yCoord(*max);
 
-  // Loop over each slice group
-  for(auto slice = static_cast<size_t>(m_SliceRange[0]); slice <= static_cast<size_t>(m_SliceRange[1]); slice++)
-  {
-    size_t sliceIndex = slice - m_SliceRange[0];
-
-    int64_t layerThickness = m_Cache->layerThicknesses[sliceIndex];
-    cummulativeLayerThickness += static_cast<float>(layerThickness);
-
-    int64_t sliceElements = m_Cache->numElements[sliceIndex];
-
-    if(sliceElements == 0)
+    auto areaData = vertAM->getAttributeArrayAs<Int16ArrayType>(QString::fromStdString(k_Area));
+    if(areaData == nullptr)
     {
-      continue;
+      setErrorCondition(k_DataStructureError, "Failed to acquire Area DataArray");
+      return;
     }
-
-    if(sliceElements + offset > numTuples)
+    auto intensityData = vertAM->getAttributeArrayAs<Int16ArrayType>(QString::fromStdString(k_Intensity));
+    if(intensityData == nullptr)
     {
-      setErrorCondition(k_InvalidOffsetError, "Invalid offset");
+      setErrorCondition(k_DataStructureError, "Failed to acquire Intensity DataArray");
+      return;
+    }
+    auto laserTtlData = vertAM->getAttributeArrayAs<UInt8ArrayType>(QString::fromStdString(k_LaserTTL));
+    if(laserTtlData == nullptr)
+    {
+      setErrorCondition(k_DataStructureError, "Failed to acquire LaserTTL DataArray");
+      return;
+    }
+    auto sliceData = vertAM->getAttributeArrayAs<Int16ArrayType>(QString::fromStdString(k_Slice));
+    if(sliceData == nullptr)
+    {
+      setErrorCondition(k_DataStructureError, "Failed to acquire Slice DataArray");
+      return;
+    }
+    auto timeData = vertAM->getAttributeArrayAs<DoubleArrayType>(k_Time);
+    if(timeData == nullptr)
+    {
+      setErrorCondition(k_DataStructureError, "Failed to acquire Time DataArray");
       return;
     }
 
-    hid_t sliceGroup = H5Utilities::createGroup(dataGroup, std::to_string(slice));
-    if(sliceGroup < 0)
+    float cummulativeLayerThickness = 0.0F; // Assumes microns? Maybe?
+    double currentTime = 0.0;
+    QDateTime initialTime;
+
+    hid_t dataGroup = H5Utilities::openHDF5Object(fileId, k_TDMSData);
+    if(dataGroup < 0)
     {
-      setErrorCondition(k_HDF5GroupOpenError, "Failed to open HDF5 slice group");
+      setErrorCondition(k_HDF5FileOpenError, "Failed to open HDF5 file");
       return;
     }
-    H5ScopedGroupSentinel sliceGroupSentinel(sliceGroup, true);
+    H5ScopedGroupSentinel dataGroupSentinel(dataGroup, true);
 
-    herr_t err = H5Lite::readPointerDataset(sliceGroup, k_Area, areaData->getTuplePointer(offset));
-    if(err < 0)
     {
-      setErrorCondition(k_HDF5DatasetError, "Failed to open HDF5 dataset Area");
-      return;
+      hid_t sliceGroup = H5Utilities::openHDF5Object(dataGroup, std::to_string(m_SliceRange[0]));
+      if(sliceGroup < 0)
+      {
+        setErrorCondition(k_HDF5GroupOpenError, "Failed to open HDF5 slice group");
+        return;
+      }
+      H5ScopedGroupSentinel sliceGroupSentinel(sliceGroup, true);
+
+      std::string partStartTimeString;
+      herr_t err = H5Lite::readStringAttribute(sliceGroup, k_PartStartTime, partStartTimeString);
+      if(err < 0)
+      {
+        setErrorCondition(k_HDF5AttributeError, "Failed to open HDF5 attribute PartStartTime");
+        return;
+      }
+
+      initialTime = QDateTime::fromString(QString::fromStdString(partStartTimeString), Qt::DateFormat::ISODateWithMs);
     }
 
-    err = H5Lite::readPointerDataset(sliceGroup, k_Intensity, intensityData->getTuplePointer(offset));
-    if(err < 0)
+    // Loop over each slice group
+    for(auto slice = static_cast<size_t>(m_SliceRange[0]); slice <= static_cast<size_t>(m_SliceRange[1]); slice++)
     {
-      setErrorCondition(k_HDF5DatasetError, "Failed to open HDF5 dataset Intensity");
-      return;
+      size_t sliceIndex = slice - m_SliceRange[0];
+
+      int64_t layerThickness = cache.layerThicknesses[sliceIndex];
+      cummulativeLayerThickness += static_cast<float>(layerThickness);
+
+      int64_t sliceElements = cache.numElements[sliceIndex];
+
+      if(sliceElements == 0)
+      {
+        continue;
+      }
+
+      if(sliceElements + offset > numTuples)
+      {
+        setErrorCondition(k_InvalidOffsetError, "Invalid offset");
+        return;
+      }
+
+      hid_t sliceGroup = H5Utilities::openHDF5Object(dataGroup, std::to_string(slice));
+      if(sliceGroup < 0)
+      {
+        setErrorCondition(k_HDF5GroupOpenError, "Failed to open HDF5 slice group");
+        return;
+      }
+      H5ScopedGroupSentinel sliceGroupSentinel(sliceGroup, true);
+
+      herr_t err = H5Lite::readPointerDataset(sliceGroup, k_Area, areaData->getTuplePointer(offset));
+      if(err < 0)
+      {
+        setErrorCondition(k_HDF5DatasetError, "Failed to open HDF5 dataset Area");
+        return;
+      }
+
+      err = H5Lite::readPointerDataset(sliceGroup, k_Intensity, intensityData->getTuplePointer(offset));
+      if(err < 0)
+      {
+        setErrorCondition(k_HDF5DatasetError, "Failed to open HDF5 dataset Intensity");
+        return;
+      }
+
+      err = H5Lite::readPointerDataset(sliceGroup, k_LaserTTL, laserTtlData->getTuplePointer(offset));
+      if(err < 0)
+      {
+        setErrorCondition(k_HDF5DatasetError, "Failed to open HDF5 dataset LaserTTL");
+        return;
+      }
+
+      // Read the XY coordinates
+      err = H5Lite::readPointerDataset(sliceGroup, k_XAxis, xCoord.data());
+      if(err < 0)
+      {
+        setErrorCondition(k_HDF5DatasetError, "Failed to open HDF5 dataset X-Axis");
+        return;
+      }
+
+      err = H5Lite::readPointerDataset(sliceGroup, k_YAxis, yCoord.data());
+      if(err < 0)
+      {
+        setErrorCondition(k_HDF5DatasetError, "Failed to open HDF5 dataset Y-Axis");
+        return;
+      }
+
+      std::string partStartTimeString;
+      err = H5Lite::readStringAttribute(sliceGroup, k_PartStartTime, partStartTimeString);
+      if(err < 0)
+      {
+        setErrorCondition(k_HDF5AttributeError, "Failed to open HDF5 attribute PartStartTime");
+        return;
+      }
+
+      std::string partEndTimeString;
+      err = H5Lite::readStringAttribute(sliceGroup, k_PartEndTime, partEndTimeString);
+      if(err < 0)
+      {
+        setErrorCondition(k_HDF5AttributeError, "Failed to open HDF5 attribute PartEndTime");
+        return;
+      }
+
+      QDateTime partStartTime = QDateTime::fromString(QString::fromStdString(partStartTimeString), Qt::DateFormat::ISODateWithMs);
+      QDateTime partEndTime = QDateTime::fromString(QString::fromStdString(partEndTimeString), Qt::DateFormat::ISODateWithMs);
+
+      currentTime = static_cast<double>(initialTime.msecsTo(partStartTime)) / 1000.0;
+
+      int64_t partDeltaTime = partStartTime.msecsTo(partEndTime);
+
+      double deltaTime = std::nearbyint(static_cast<double>(partDeltaTime) / static_cast<double>(sliceElements) * 1000.0) / 1e6;
+
+      // Now fill in the appropriate parts of the sliceData array and vertex array
+      for(size_t i = offset; i < offset + sliceElements; i++)
+      {
+        (*sliceData)[i] = static_cast<int16_t>(slice);
+        (*timeData)[i] = currentTime;
+
+        std::array<float, 3> coord = {static_cast<float>(xCoord[i - offset]), static_cast<float>(yCoord[i - offset]), cummulativeLayerThickness};
+        vertGeom->setCoords(i, coord.data());
+
+        currentTime += deltaTime;
+      }
+
+      offset += sliceElements;
     }
-
-    err = H5Lite::readPointerDataset(sliceGroup, k_LaserTTL, laserTtlData->getTuplePointer(offset));
-    if(err < 0)
-    {
-      setErrorCondition(k_HDF5DatasetError, "Failed to open HDF5 dataset LaserTTL");
-      return;
-    }
-
-    // Read the XY coordinates
-    err = H5Lite::readPointerDataset(sliceGroup, k_XAxis, xCoord.data());
-    if(err < 0)
-    {
-      setErrorCondition(k_HDF5DatasetError, "Failed to open HDF5 dataset X-Axis");
-      return;
-    }
-
-    err = H5Lite::readPointerDataset(sliceGroup, k_YAxis, yCoord.data());
-    if(err < 0)
-    {
-      setErrorCondition(k_HDF5DatasetError, "Failed to open HDF5 dataset Y-Axis");
-      return;
-    }
-
-    std::string partStartTimeString;
-    err = H5Lite::readStringAttribute(sliceGroup, k_PartStartTime, partStartTimeString);
-    if(err < 0)
-    {
-      setErrorCondition(k_HDF5AttributeError, "Failed to open HDF5 attribute PartStartTime");
-      return;
-    }
-
-    std::string partEndTimeString;
-    err = H5Lite::readStringAttribute(sliceGroup, k_PartEndTime, partEndTimeString);
-    if(err < 0)
-    {
-      setErrorCondition(k_HDF5AttributeError, "Failed to open HDF5 attribute PartEndTime");
-      return;
-    }
-
-    QDateTime partStartTime = QDateTime::fromString(QString::fromStdString(partStartTimeString), Qt::DateFormat::ISODateWithMs);
-    QDateTime partEndTime = QDateTime::fromString(QString::fromStdString(partEndTimeString), Qt::DateFormat::ISODateWithMs);
-
-    currentTime = static_cast<double>(initialTime.msecsTo(partStartTime)) / 1000.0;
-
-    int64_t partDeltaTime = partStartTime.msecsTo(partEndTime);
-
-    double deltaTime = std::nearbyint(static_cast<double>(partDeltaTime) / static_cast<double>(sliceElements) * 1000.0) / 1e6;
-
-    // Now fill in the appropriate parts of the sliceData array and vertex array
-    for(size_t i = offset; i < offset + sliceElements; i++)
-    {
-      (*sliceData)[i] = static_cast<int16_t>(slice);
-      (*timeData)[i] = currentTime;
-
-      std::array<float, 3> coord = {static_cast<float>(xCoord[i - offset]), static_cast<float>(yCoord[i - offset]), cummulativeLayerThickness};
-      vertGeom->setCoords(i, coord.data());
-
-      currentTime += deltaTime;
-    }
-
-    offset += sliceElements;
   }
 }
 
@@ -706,16 +785,28 @@ QString ImportQMMeltpoolH5File::ClassName()
 }
 
 // -----------------------------------------------------------------------------
-void ImportQMMeltpoolH5File::setHDF5FilePath(const QString& value)
+void ImportQMMeltpoolH5File::setInputFiles(const VectString& value)
 {
-  m_HDF5FilePath = value;
+  m_InputFiles = value;
 }
 
 // -----------------------------------------------------------------------------
-QString ImportQMMeltpoolH5File::getHDF5FilePath() const
+ImportQMMeltpoolH5File::VectString ImportQMMeltpoolH5File::getInputFiles() const
 {
-  return m_HDF5FilePath;
+  return m_InputFiles;
 }
+
+//// -----------------------------------------------------------------------------
+// void ImportQMMeltpoolH5File::setHDF5FilePath(const QString& value)
+//{
+//  m_HDF5FilePath = value;
+//}
+
+//// -----------------------------------------------------------------------------
+// QString ImportQMMeltpoolH5File::getHDF5FilePath() const
+//{
+//  return m_HDF5FilePath;
+//}
 
 // -----------------------------------------------------------------------------
 void ImportQMMeltpoolH5File::setDataContainerPath(const DataArrayPath& value)

--- a/DREAM3DReviewFilters/ImportQMMeltpoolH5File.cpp
+++ b/DREAM3DReviewFilters/ImportQMMeltpoolH5File.cpp
@@ -138,7 +138,6 @@ struct ImportQMMeltpoolH5File::Cache
   void flush()
   {
     filePath = "";
-    // lastModified = QDateTime();
     sliceRange = {};
 
     missingIndices.clear();

--- a/DREAM3DReviewFilters/ImportQMMeltpoolH5File.cpp
+++ b/DREAM3DReviewFilters/ImportQMMeltpoolH5File.cpp
@@ -127,7 +127,6 @@ std::string make_list_string(const Container& items)
 
 struct ImportQMMeltpoolH5File::Cache
 {
-  // QDateTime lastModified;
   fs::file_time_type lastModified;
   std::string filePath;
   IntVec2Type sliceRange;

--- a/DREAM3DReviewFilters/ImportQMMeltpoolH5File.h
+++ b/DREAM3DReviewFilters/ImportQMMeltpoolH5File.h
@@ -55,7 +55,6 @@ class DREAM3DReview_EXPORT ImportQMMeltpoolH5File : public AbstractFilter
   PYB11_SHARED_POINTERS(ImportQMMeltpoolH5File)
   PYB11_FILTER_NEW_MACRO(ImportQMMeltpoolH5File)
   PYB11_PROPERTY(VectString InputFiles READ getInputFiles WRITE setInputFiles)
-  PYB11_PROPERTY(QString HDF5FilePath READ getHDF5FilePath WRITE setHDF5FilePath)
   PYB11_PROPERTY(DataArrayPath DataContainerPath READ getDataContainerPath WRITE setDataContainerPath)
   PYB11_PROPERTY(QString VertexAttributeMatrixName READ getVertexAttributeMatrixName WRITE setVertexAttributeMatrixName)
   PYB11_PROPERTY(IntVec2Type SliceRange READ getSliceRange WRITE setSliceRange)

--- a/DREAM3DReviewFilters/ImportQMMeltpoolH5File.h
+++ b/DREAM3DReviewFilters/ImportQMMeltpoolH5File.h
@@ -232,11 +232,6 @@ protected:
   void dataCheck() override;
 
   /**
-   * @brief Initializes all the private instance variables.
-   */
-  void initialize();
-
-  /**
    * @brief generateCache
    * @param device
    * @return

--- a/DREAM3DReviewFilters/ImportQMMeltpoolH5File.h
+++ b/DREAM3DReviewFilters/ImportQMMeltpoolH5File.h
@@ -33,9 +33,12 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/Common/SIMPLArray.hpp"
+#include "SIMPLib/FilterParameters/StackFileListInfo.h"
 #include "SIMPLib/Filtering/AbstractFilter.h"
 
 #include "DREAM3DReview/DREAM3DReviewPlugin.h"
@@ -51,6 +54,7 @@ class DREAM3DReview_EXPORT ImportQMMeltpoolH5File : public AbstractFilter
   PYB11_FILTER()
   PYB11_SHARED_POINTERS(ImportQMMeltpoolH5File)
   PYB11_FILTER_NEW_MACRO(ImportQMMeltpoolH5File)
+  PYB11_PROPERTY(VectString InputFiles READ getInputFiles WRITE setInputFiles)
   PYB11_PROPERTY(QString HDF5FilePath READ getHDF5FilePath WRITE setHDF5FilePath)
   PYB11_PROPERTY(DataArrayPath DataContainerPath READ getDataContainerPath WRITE setDataContainerPath)
   PYB11_PROPERTY(QString VertexAttributeMatrixName READ getVertexAttributeMatrixName WRITE setVertexAttributeMatrixName)
@@ -69,6 +73,9 @@ public:
 
   static Pointer New();
 
+  using VectString = std::vector<std::string>;
+  struct Cache;
+
   /**
    * @brief Returns the name of the class for ImportQMMeltpoolH5File
    */
@@ -82,17 +89,28 @@ public:
   ~ImportQMMeltpoolH5File() override;
 
   /**
-   * @brief Sets the value for Filter Parameter for HDF5FilePath
-   * @param value The new value to use.
+   * @brief Setter property for InputFileListInfo
    */
-  void setHDF5FilePath(const QString& value);
-
+  void setInputFiles(const VectString& value);
   /**
-   * @brief Gets the Filter Parameter value for HDF5FilePath
-   * @return The value for HDF5FilePath
+   * @brief Getter property for InputFileListInfo
+   * @return Value of InputFileListInfo
    */
-  QString getHDF5FilePath() const;
-  Q_PROPERTY(QString HDF5FilePath READ getHDF5FilePath WRITE setHDF5FilePath)
+  VectString getInputFiles() const;
+  Q_PROPERTY(VectString InputFiles READ getInputFiles WRITE setInputFiles)
+
+  //  /**
+  //   * @brief Sets the value for Filter Parameter for HDF5FilePath
+  //   * @param value The new value to use.
+  //   */
+  //  void setHDF5FilePath(const QString& value);
+
+  //  /**
+  //   * @brief Gets the Filter Parameter value for HDF5FilePath
+  //   * @return The value for HDF5FilePath
+  //   */
+  //  QString getHDF5FilePath() const;
+  //  Q_PROPERTY(QString HDF5FilePath READ getHDF5FilePath WRITE setHDF5FilePath)
 
   /**
    * @brief Sets the value for Filter Parameter for DataContainerPath
@@ -224,7 +242,7 @@ protected:
    * @param device
    * @return
    */
-  void generateCache();
+  void generateCache(Cache& cache);
 
   /**
    * @brief generateDataStructure
@@ -236,16 +254,23 @@ protected:
    */
   void readDataFromFile();
 
+  /**
+   * @brief createUpdateCacheEntries
+   * @param filePath
+   */
+  void createUpdateCacheEntries();
+
 private:
-  QString m_HDF5FilePath = {};
+  VectString m_InputFiles = {};
+
+  // QString m_HDF5FilePath = {};
   DataArrayPath m_DataContainerPath = {"MeltPoolData", "", ""};
   QString m_VertexAttributeMatrixName = {"Vertex Data"};
   IntVec2Type m_SliceRange = {0, 0};
   float m_Power = 0.0f;
   QString m_PossibleIndices = "";
 
-  struct Cache;
-  std::unique_ptr<Cache> m_Cache;
+  std::vector<Cache> m_Caches;
 
 public:
   ImportQMMeltpoolH5File(const ImportQMMeltpoolH5File&) = delete;            // Copy Constructor Not Implemented

--- a/DREAM3DReviewFilters/ImportVolumeGraphicsFile.cpp
+++ b/DREAM3DReviewFilters/ImportVolumeGraphicsFile.cpp
@@ -223,8 +223,6 @@ void ImportVolumeGraphicsFile::dataCheck()
 // -----------------------------------------------------------------------------
 void ImportVolumeGraphicsFile::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/InsertTransformationPhases.cpp
+++ b/DREAM3DReviewFilters/InsertTransformationPhases.cpp
@@ -361,9 +361,10 @@ void InsertTransformationPhases::initialize()
 // -----------------------------------------------------------------------------
 void InsertTransformationPhases::dataCheck()
 {
-  DataArrayPath tempPath;
+
   clearErrorCode();
   clearWarningCode();
+  DataArrayPath tempPath;
 
   DataContainer::Pointer m = getDataContainerArray()->getPrereqDataContainer(this, m_FeatureIdsArrayPath.getDataContainerName(), false);
   if(getErrorCode() < 0 || m == nullptr)
@@ -492,8 +493,6 @@ void InsertTransformationPhases::dataCheck()
 // -----------------------------------------------------------------------------
 void InsertTransformationPhases::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/InterpolateMeshToRegularGrid.cpp
+++ b/DREAM3DReviewFilters/InterpolateMeshToRegularGrid.cpp
@@ -658,8 +658,6 @@ void InterpolateMeshToRegularGrid::dataCheck()
 // -----------------------------------------------------------------------------
 void InterpolateMeshToRegularGrid::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/InterpolatePointCloudToRegularGrid.cpp
+++ b/DREAM3DReviewFilters/InterpolatePointCloudToRegularGrid.cpp
@@ -501,8 +501,6 @@ void InterpolatePointCloudToRegularGrid::mapKernelDistances(int64_t kernel[3], s
 // -----------------------------------------------------------------------------
 void InterpolatePointCloudToRegularGrid::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/InterpolatePointCloudToRegularGrid.cpp
+++ b/DREAM3DReviewFilters/InterpolatePointCloudToRegularGrid.cpp
@@ -45,8 +45,8 @@ InterpolatePointCloudToRegularGrid::InterpolatePointCloudToRegularGrid()
 , m_ArraysToInterpolate(QVector<DataArrayPath>())
 , m_ArraysToCopy(QVector<DataArrayPath>())
 , m_VoxelIndicesArrayPath("", "", "VoxelIndices")
-, m_InterpolatedDataContainerName("InterpolatedDataContainer")
-, m_InterpolatedAttributeMatrixName("InterpolatedAttributeMatrix")
+, m_InterpolatedDataContainerName("Interpolated DataContainer")
+, m_InterpolatedAttributeMatrixName("Interpolated AttributeMatrix")
 , m_MaskArrayPath("", "", "")
 , m_KernelDistancesArrayName("KernelDistances")
 {
@@ -124,29 +124,11 @@ void InterpolatePointCloudToRegularGrid::setupFilterParameters()
                                                       InterpolatePointCloudToRegularGrid));
   parameters.push_back(SIMPL_NEW_DA_WITH_LINKED_AM_FP("Kernel Distances", KernelDistancesArrayName, InterpolatedDataContainerName, InterpolatedAttributeMatrixName, FilterParameter::CreatedArray,
                                                       InterpolatePointCloudToRegularGrid));
-  setFilterParameters(parameters);
-}
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void InterpolatePointCloudToRegularGrid::readFilterParameters(AbstractFilterParametersReader* reader, int index)
-{
-  reader->openFilterGroup(this, index);
-  setDataContainerName(reader->readDataArrayPath("DataContainerName", getDataContainerName()));
-  setArraysToInterpolate(reader->readDataArrayPathVector("ArraysToInterpolate", getArraysToInterpolate()));
-  setArraysToCopy(reader->readDataArrayPathVector("ArraysToCopy", getArraysToCopy()));
-  setVoxelIndicesArrayPath(reader->readDataArrayPath("VoxelIndicesArrayPath", getVoxelIndicesArrayPath()));
-  setInterpolatedDataContainerName(reader->readDataArrayPath("InterpolatedDataContainerName", getInterpolatedDataContainerName()));
-  setInterpolatedAttributeMatrixName(reader->readString("InterpolatedAttributeMatrixName", getInterpolatedAttributeMatrixName()));
-  setInterpolationTechnique(reader->readValue("InterpolationTechnique", getInterpolationTechnique()));
-  setKernelSize(reader->readFloatVec3("KernelSize", getKernelSize()));
-  setSigmas(reader->readFloatVec3("Sigmas", getSigmas()));
-  setUseMask(reader->readValue("UseMask", getUseMask()));
-  setMaskArrayPath(reader->readDataArrayPath("MaskArrayPath", getMaskArrayPath()));
-  setStoreKernelDistances(reader->readValue("StoreKernelDistances", getStoreKernelDistances()));
-  setKernelDistancesArrayName(reader->readString("KernelDistancesArrayName", getKernelDistancesArrayName()));
-  reader->closeFilterGroup();
+  parameters.push_back(SIMPL_NEW_STRING_FP("Interpolated Array Suffix", InterpolatedSuffix, FilterParameter::Parameter, InterpolatePointCloudToRegularGrid));
+  parameters.push_back(SIMPL_NEW_STRING_FP("Copied Array Suffix", CopySuffix, FilterParameter::Parameter, InterpolatePointCloudToRegularGrid));
+
+  setFilterParameters(parameters);
 }
 
 // -----------------------------------------------------------------------------
@@ -315,7 +297,7 @@ void InterpolatePointCloudToRegularGrid::dataCheck()
         {
           for(int32_t i = 0; i < interpolatePaths.size(); i++)
           {
-            tempPath.update(getInterpolatedDataContainerName().getDataContainerName(), getInterpolatedAttributeMatrixName(), interpolatePaths[i].getDataArrayName() + "Interpolation");
+            tempPath.update(getInterpolatedDataContainerName().getDataContainerName(), getInterpolatedAttributeMatrixName(), interpolatePaths[i].getDataArrayName() + getInterpolatedSuffix());
             IDataArray::Pointer tmpDataArray = tmpAttrMat->getPrereqIDataArray(this, interpolatePaths[i].getDataArrayName(), -90002);
             if(getErrorCode() >= 0)
             {
@@ -334,7 +316,7 @@ void InterpolatePointCloudToRegularGrid::dataCheck()
 
           for(int32_t i = 0; i < copyPaths.size(); i++)
           {
-            tempPath.update(getInterpolatedDataContainerName().getDataContainerName(), getInterpolatedAttributeMatrixName(), copyPaths[i].getDataArrayName() + "Copy");
+            tempPath.update(getInterpolatedDataContainerName().getDataContainerName(), getInterpolatedAttributeMatrixName(), copyPaths[i].getDataArrayName() + getCopySuffix());
             IDataArray::Pointer tmpDataArray = tmpAttrMat->getPrereqIDataArray(this, copyPaths[i].getDataArrayName(), -90002);
             if(getErrorCode() >= 0)
             {
@@ -903,4 +885,28 @@ void InterpolatePointCloudToRegularGrid::setKernelDistancesArrayName(const QStri
 QString InterpolatePointCloudToRegularGrid::getKernelDistancesArrayName() const
 {
   return m_KernelDistancesArrayName;
+}
+
+// -----------------------------------------------------------------------------
+void InterpolatePointCloudToRegularGrid::setInterpolatedSuffix(const QString& value)
+{
+  m_InterpolatedSuffix = value;
+}
+
+// -----------------------------------------------------------------------------
+QString InterpolatePointCloudToRegularGrid::getInterpolatedSuffix() const
+{
+  return m_InterpolatedSuffix;
+}
+
+// -----------------------------------------------------------------------------
+void InterpolatePointCloudToRegularGrid::setCopySuffix(const QString& value)
+{
+  m_CopySuffix = value;
+}
+
+// -----------------------------------------------------------------------------
+QString InterpolatePointCloudToRegularGrid::getCopySuffix() const
+{
+  return m_CopySuffix;
 }

--- a/DREAM3DReviewFilters/InterpolatePointCloudToRegularGrid.h
+++ b/DREAM3DReviewFilters/InterpolatePointCloudToRegularGrid.h
@@ -36,7 +36,21 @@ class DREAM3DReview_EXPORT InterpolatePointCloudToRegularGrid : public AbstractF
   PYB11_FILTER()
   PYB11_SHARED_POINTERS(InterpolatePointCloudToRegularGrid)
   PYB11_FILTER_NEW_MACRO(InterpolatePointCloudToRegularGrid)
-
+  PYB11_PROPERTY(DataArrayPath DataContainerName READ getDataContainerName WRITE setDataContainerName)
+  PYB11_PROPERTY(QVector<DataArrayPath> ArraysToInterpolate READ getArraysToInterpolate WRITE setArraysToInterpolate)
+  PYB11_PROPERTY(QVector<DataArrayPath> ArraysToCopy READ getArraysToCopy WRITE setArraysToCopy)
+  PYB11_PROPERTY(DataArrayPath VoxelIndicesArrayPath READ getVoxelIndicesArrayPath WRITE setVoxelIndicesArrayPath)
+  PYB11_PROPERTY(DataArrayPath InterpolatedDataContainerName READ getInterpolatedDataContainerName WRITE setInterpolatedDataContainerName)
+  PYB11_PROPERTY(QString InterpolatedAttributeMatrixName READ getInterpolatedAttributeMatrixName WRITE setInterpolatedAttributeMatrixName)
+  PYB11_PROPERTY(int InterpolationTechnique READ getInterpolationTechnique WRITE setInterpolationTechnique)
+  PYB11_PROPERTY(FloatVec3Type KernelSize READ getKernelSize WRITE setKernelSize)
+  PYB11_PROPERTY(FloatVec3Type Sigmas READ getSigmas WRITE setSigmas)
+  PYB11_PROPERTY(bool UseMask READ getUseMask WRITE setUseMask)
+  PYB11_PROPERTY(DataArrayPath MaskArrayPath READ getMaskArrayPath WRITE setMaskArrayPath)
+  PYB11_PROPERTY(bool StoreKernelDistances READ getStoreKernelDistances WRITE setStoreKernelDistances)
+  PYB11_PROPERTY(QString KernelDistancesArrayName READ getKernelDistancesArrayName WRITE setKernelDistancesArrayName)
+  PYB11_PROPERTY(QString InterpolatedSuffix READ getInterpolatedSuffix WRITE setInterpolatedSuffix)
+  PYB11_PROPERTY(QString CopySuffix READ getCopySuffix WRITE setCopySuffix)
   PYB11_END_BINDINGS()
 
 public:

--- a/DREAM3DReviewFilters/InterpolatePointCloudToRegularGrid.h
+++ b/DREAM3DReviewFilters/InterpolatePointCloudToRegularGrid.h
@@ -32,6 +32,12 @@
 class DREAM3DReview_EXPORT InterpolatePointCloudToRegularGrid : public AbstractFilter
 {
   Q_OBJECT
+  PYB11_BEGIN_BINDINGS(InterpolatePointCloudToRegularGrid SUPERCLASS AbstractFilter)
+  PYB11_FILTER()
+  PYB11_SHARED_POINTERS(InterpolatePointCloudToRegularGrid)
+  PYB11_FILTER_NEW_MACRO(InterpolatePointCloudToRegularGrid)
+
+  PYB11_END_BINDINGS()
 
 public:
   using Self = InterpolatePointCloudToRegularGrid;
@@ -198,6 +204,28 @@ public:
   Q_PROPERTY(QString KernelDistancesArrayName READ getKernelDistancesArrayName WRITE setKernelDistancesArrayName)
 
   /**
+   * @brief Setter property for KernelDistancesArrayName
+   */
+  void setInterpolatedSuffix(const QString& value);
+  /**
+   * @brief Getter property for KernelDistancesArrayName
+   * @return Value of KernelDistancesArrayName
+   */
+  QString getInterpolatedSuffix() const;
+  Q_PROPERTY(QString InterpolatedSuffix READ getInterpolatedSuffix WRITE setInterpolatedSuffix)
+
+  /**
+   * @brief Setter property for KernelDistancesArrayName
+   */
+  void setCopySuffix(const QString& value);
+  /**
+   * @brief Getter property for KernelDistancesArrayName
+   * @return Value of KernelDistancesArrayName
+   */
+  QString getCopySuffix() const;
+  Q_PROPERTY(QString CopySuffix READ getCopySuffix WRITE setCopySuffix)
+
+  /**
    * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
    */
   QString getCompiledLibraryName() const override;
@@ -240,11 +268,6 @@ public:
    * @brief setupFilterParameters Reimplemented from @see AbstractFilter class
    */
   void setupFilterParameters() override;
-
-  /**
-   * @brief readFilterParameters Reimplemented from @see AbstractFilter class
-   */
-  void readFilterParameters(AbstractFilterParametersReader* reader, int index) override;
 
   /**
    * @brief execute Reimplemented from @see AbstractFilter class
@@ -313,6 +336,9 @@ private:
   DataArrayPath m_MaskArrayPath = {};
   bool m_StoreKernelDistances = false;
   QString m_KernelDistancesArrayName = {};
+
+  QString m_InterpolatedSuffix = " [Interpolated]";
+  QString m_CopySuffix = " [Copied]";
 
   NeighborList<float>::WeakPointer m_KernelDistances = NeighborList<float>::NullPointer();
 

--- a/DREAM3DReviewFilters/KDistanceGraph.cpp
+++ b/DREAM3DReviewFilters/KDistanceGraph.cpp
@@ -181,8 +181,6 @@ void KDistanceGraph::dataCheck()
 // -----------------------------------------------------------------------------
 void KDistanceGraph::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/KMeans.cpp
+++ b/DREAM3DReviewFilters/KMeans.cpp
@@ -276,8 +276,6 @@ void KMeans::dataCheck()
 // -----------------------------------------------------------------------------
 void KMeans::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/KMedoids.cpp
+++ b/DREAM3DReviewFilters/KMedoids.cpp
@@ -271,8 +271,6 @@ void KMedoids::dataCheck()
 // -----------------------------------------------------------------------------
 void KMedoids::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/LabelTriangleGeometry.cpp
+++ b/DREAM3DReviewFilters/LabelTriangleGeometry.cpp
@@ -123,8 +123,6 @@ void LabelTriangleGeometry::dataCheck()
 // -----------------------------------------------------------------------------
 void LabelTriangleGeometry::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/LaplacianSmoothPointCloud.cpp
+++ b/DREAM3DReviewFilters/LaplacianSmoothPointCloud.cpp
@@ -156,8 +156,6 @@ void LaplacianSmoothPointCloud::determineNewCoords(float* vertex, int64_t vertId
 // -----------------------------------------------------------------------------
 void LaplacianSmoothPointCloud::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/LocalDislocationDensityCalculator.cpp
+++ b/DREAM3DReviewFilters/LocalDislocationDensityCalculator.cpp
@@ -165,10 +165,9 @@ void LocalDislocationDensityCalculator::initialize()
 // -----------------------------------------------------------------------------
 void LocalDislocationDensityCalculator::dataCheck()
 {
-  DataArrayPath tempPath;
   clearErrorCode();
   clearWarningCode();
-
+  DataArrayPath tempPath;
   // First sanity check the inputs and output names. All must be filled in
 
   if(getOutputDataContainerName().isEmpty())
@@ -279,15 +278,12 @@ void LocalDislocationDensityCalculator::dataCheck()
 // -----------------------------------------------------------------------------
 void LocalDislocationDensityCalculator::execute()
 {
-  QString ss;
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {
     return;
   }
-
+  QString ss;
   DataContainer::Pointer edc = getDataContainerArray()->getDataContainer(getEdgeDataContainerName());
   DataContainer::Pointer vdc = getDataContainerArray()->getDataContainer(getOutputDataContainerName());
   AttributeMatrix::Pointer cellAttrMat = vdc->getAttributeMatrix(getOutputAttributeMatrixName());

--- a/DREAM3DReviewFilters/MapPointCloudToRegularGrid.cpp
+++ b/DREAM3DReviewFilters/MapPointCloudToRegularGrid.cpp
@@ -358,8 +358,6 @@ void MapPointCloudToRegularGrid::createRegularGrid()
 // -----------------------------------------------------------------------------
 void MapPointCloudToRegularGrid::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/MapPointCloudToRegularGrid.cpp
+++ b/DREAM3DReviewFilters/MapPointCloudToRegularGrid.cpp
@@ -22,6 +22,7 @@
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/DataArrayCreationFilterParameter.h"
 #include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
+#include "SIMPLib/FilterParameters/DataContainerCreationFilterParameter.h"
 #include "SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h"
 #include "SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/LinkedChoicesFilterParameter.h"
@@ -33,6 +34,11 @@
 #include "DREAM3DReview/DREAM3DReviewConstants.h"
 #include "DREAM3DReview/DREAM3DReviewVersion.h"
 
+namespace
+{
+constexpr int32_t k_CreateSamplingGrid = 0;
+constexpr int32_t k_UseExistingSamplingGrid = 1;
+} // namespace
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -55,9 +61,9 @@ void MapPointCloudToRegularGrid::setupFilterParameters()
   {
     LinkedChoicesFilterParameter::Pointer parameter = LinkedChoicesFilterParameter::New();
     parameter->setHumanLabel("Sampling Grid Type");
-    parameter->setPropertyName("CreateDataContainer");
-    parameter->setSetterCallback(SIMPL_BIND_SETTER(MapPointCloudToRegularGrid, this, CreateDataContainer));
-    parameter->setGetterCallback(SIMPL_BIND_GETTER(MapPointCloudToRegularGrid, this, CreateDataContainer));
+    parameter->setPropertyName("SamplingGridType");
+    parameter->setSetterCallback(SIMPL_BIND_SETTER(MapPointCloudToRegularGrid, this, SamplingGridType));
+    parameter->setGetterCallback(SIMPL_BIND_GETTER(MapPointCloudToRegularGrid, this, SamplingGridType));
 
     QVector<QString> choices;
     choices.push_back("Manual");
@@ -65,19 +71,19 @@ void MapPointCloudToRegularGrid::setupFilterParameters()
     parameter->setChoices(choices);
     QStringList linkedProps2;
     linkedProps2 << "GridDimensions"
-                 << "ImageDataContainerName"
+                 << "CreatedImageDataContainerName"
                  << "ImageDataContainerPath";
     parameter->setLinkedProperties(linkedProps2);
     parameter->setEditable(false);
     parameter->setCategory(FilterParameter::Parameter);
     parameters.push_back(parameter);
   }
-  parameters.push_back(SIMPL_NEW_INT_VEC3_FP("Grid Dimensions", GridDimensions, FilterParameter::Parameter, MapPointCloudToRegularGrid, 0));
+  parameters.push_back(SIMPL_NEW_INT_VEC3_FP("Grid Dimensions", GridDimensions, FilterParameter::Parameter, MapPointCloudToRegularGrid, k_CreateSamplingGrid));
   {
     DataContainerSelectionFilterParameter::RequirementType req;
     IGeometry::Types reqGeom = {IGeometry::Type::Image};
     req.dcGeometryTypes = reqGeom;
-    parameters.push_back(SIMPL_NEW_DC_SELECTION_FP("ImageDataContainerPath", ImageDataContainerPath, FilterParameter::RequiredArray, MapPointCloudToRegularGrid, req, 1));
+    parameters.push_back(SIMPL_NEW_DC_SELECTION_FP("ImageDataContainerPath", ImageDataContainerPath, FilterParameter::RequiredArray, MapPointCloudToRegularGrid, req, k_UseExistingSamplingGrid));
   }
   {
     DataContainerSelectionFilterParameter::RequirementType req;
@@ -97,24 +103,9 @@ void MapPointCloudToRegularGrid::setupFilterParameters()
     DataArrayCreationFilterParameter::RequirementType req = DataArrayCreationFilterParameter::CreateRequirement(AttributeMatrix::Type::Vertex, IGeometry::Type::Vertex);
     parameters.push_back(SIMPL_NEW_DA_CREATION_FP("Voxel Indices", VoxelIndicesArrayPath, FilterParameter::CreatedArray, MapPointCloudToRegularGrid, req));
   }
-  setFilterParameters(parameters);
-}
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void MapPointCloudToRegularGrid::readFilterParameters(AbstractFilterParametersReader* reader, int index)
-{
-  reader->openFilterGroup(this, index);
-  setDataContainerName(reader->readDataArrayPath("DataContainerName", getDataContainerName()));
-  setImageDataContainerPath(reader->readDataArrayPath("ImageDataContainerPath", getImageDataContainerPath()));
-  setImageDataContainerName(reader->readString("ImageDataContainerName", getImageDataContainerName()));
-  setVoxelIndicesArrayPath(reader->readDataArrayPath("VoxelIndicesArrayPath", getVoxelIndicesArrayPath()));
-  setGridDimensions(reader->readIntVec3("GridDimensions", getGridDimensions()));
-  setUseMask(reader->readValue("UseMask", getUseMask()));
-  setCreateDataContainer(reader->readValue("CreateDataContainer", getCreateDataContainer()));
-  setMaskArrayPath(reader->readDataArrayPath("MaskArrayPath", getMaskArrayPath()));
-  reader->closeFilterGroup();
+  parameters.push_back(SIMPL_NEW_DC_CREATION_FP("Created Image DataContainer", CreatedImageDataContainerName, FilterParameter::CreatedArray, MapPointCloudToRegularGrid, k_CreateSamplingGrid));
+  setFilterParameters(parameters);
 }
 
 // -----------------------------------------------------------------------------
@@ -146,7 +137,7 @@ void MapPointCloudToRegularGrid::dataCheck()
 
   dataArrays.push_back(vertex->getVertices());
 
-  if(m_CreateDataContainer == 0)
+  if(m_SamplingGridType == k_CreateSamplingGrid)
   {
     if(getGridDimensions()[0] <= 0 || getGridDimensions()[1] <= 0 || getGridDimensions()[2] <= 0)
     {
@@ -167,7 +158,7 @@ void MapPointCloudToRegularGrid::dataCheck()
     size_t dims[3] = {static_cast<size_t>(getGridDimensions()[0]), static_cast<size_t>(getGridDimensions()[1]), static_cast<size_t>(getGridDimensions()[2])};
     image->setDimensions(dims);
 
-    DataContainer::Pointer m = getDataContainerArray()->createNonPrereqDataContainer(this, getImageDataContainerName());
+    DataContainer::Pointer m = getDataContainerArray()->createNonPrereqDataContainer(this, getCreatedImageDataContainerName());
 
     if(getErrorCode() < 0)
     {
@@ -177,7 +168,7 @@ void MapPointCloudToRegularGrid::dataCheck()
     m->setGeometry(image);
   }
 
-  if(m_CreateDataContainer == 1)
+  if(m_SamplingGridType == k_UseExistingSamplingGrid)
   {
     ImageGeom::Pointer vertex = getDataContainerArray()->getPrereqGeometryFromDataContainer<ImageGeom>(this, getImageDataContainerPath());
     if(getErrorCode() < 0)
@@ -189,7 +180,7 @@ void MapPointCloudToRegularGrid::dataCheck()
   std::vector<size_t> cDims(1, 1);
 
   m_VoxelIndicesPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<size_t>>(this, getVoxelIndicesArrayPath(), 0, cDims);
-  if(nullptr != m_VoxelIndicesPtr.lock().get())
+  if(nullptr != m_VoxelIndicesPtr.lock())
   {
     m_VoxelIndices = m_VoxelIndicesPtr.lock()->getPointer(0);
   } /* Now assign the raw pointer to data from the DataArray<T> object */
@@ -198,10 +189,10 @@ void MapPointCloudToRegularGrid::dataCheck()
     dataArrays.push_back(m_VoxelIndicesPtr.lock());
   }
 
-  if(getUseMask() == true)
+  if(getUseMask())
   {
     m_MaskPtr = getDataContainerArray()->getPrereqArrayFromPath<DataArray<bool>>(this, getMaskArrayPath(), cDims);
-    if(nullptr != m_MaskPtr.lock().get())
+    if(nullptr != m_MaskPtr.lock())
     {
       m_Mask = m_MaskPtr.lock()->getPointer(0);
     } /* Now assign the raw pointer to data from the DataArray<T> object */
@@ -223,7 +214,7 @@ void MapPointCloudToRegularGrid::createRegularGrid()
   notifyStatusMessage(ss);
 
   DataContainer::Pointer m = getDataContainerArray()->getDataContainer(getDataContainerName());
-  DataContainer::Pointer interpolatedDC = getDataContainerArray()->getDataContainer(getImageDataContainerName());
+  DataContainer::Pointer interpolatedDC = getDataContainerArray()->getDataContainer(getCreatedImageDataContainerName());
   VertexGeom::Pointer pointCloud = m->getGeometryAs<VertexGeom>();
   ImageGeom::Pointer image = interpolatedDC->getGeometryAs<ImageGeom>();
 
@@ -376,13 +367,13 @@ void MapPointCloudToRegularGrid::execute()
   }
 
   ImageGeom::Pointer image;
-  if(m_CreateDataContainer == 0)
+  if(m_SamplingGridType == 0)
   {
     // Create the regular grid
     createRegularGrid();
-    image = getDataContainerArray()->getDataContainer(getImageDataContainerName())->getGeometryAs<ImageGeom>();
+    image = getDataContainerArray()->getDataContainer(getCreatedImageDataContainerName())->getGeometryAs<ImageGeom>();
   }
-  else if(m_CreateDataContainer == 1)
+  else if(m_SamplingGridType == 1)
   {
     image = getDataContainerArray()->getDataContainer(getImageDataContainerPath())->getGeometryAs<ImageGeom>();
   }
@@ -554,15 +545,15 @@ DataArrayPath MapPointCloudToRegularGrid::getDataContainerName() const
 }
 
 // -----------------------------------------------------------------------------
-void MapPointCloudToRegularGrid::setImageDataContainerName(const QString& value)
+void MapPointCloudToRegularGrid::setCreatedImageDataContainerName(const DataArrayPath& value)
 {
-  m_ImageDataContainerName = value;
+  m_CreatedImageDataContainerName = value;
 }
 
 // -----------------------------------------------------------------------------
-QString MapPointCloudToRegularGrid::getImageDataContainerName() const
+DataArrayPath MapPointCloudToRegularGrid::getCreatedImageDataContainerName() const
 {
-  return m_ImageDataContainerName;
+  return m_CreatedImageDataContainerName;
 }
 
 // -----------------------------------------------------------------------------
@@ -614,15 +605,15 @@ bool MapPointCloudToRegularGrid::getUseMask() const
 }
 
 // -----------------------------------------------------------------------------
-void MapPointCloudToRegularGrid::setCreateDataContainer(int value)
+void MapPointCloudToRegularGrid::setSamplingGridType(int value)
 {
-  m_CreateDataContainer = value;
+  m_SamplingGridType = value;
 }
 
 // -----------------------------------------------------------------------------
-int MapPointCloudToRegularGrid::getCreateDataContainer() const
+int MapPointCloudToRegularGrid::getSamplingGridType() const
 {
-  return m_CreateDataContainer;
+  return m_SamplingGridType;
 }
 
 // -----------------------------------------------------------------------------

--- a/DREAM3DReviewFilters/MapPointCloudToRegularGrid.h
+++ b/DREAM3DReviewFilters/MapPointCloudToRegularGrid.h
@@ -35,14 +35,15 @@ class DREAM3DReview_EXPORT MapPointCloudToRegularGrid : public AbstractFilter
   PYB11_SHARED_POINTERS(MapPointCloudToRegularGrid)
   PYB11_FILTER_NEW_MACRO(MapPointCloudToRegularGrid)
   PYB11_PROPERTY(DataArrayPath DataContainerName READ getDataContainerName WRITE setDataContainerName)
-  PYB11_PROPERTY(QString ImageDataContainerName READ getImageDataContainerName WRITE setImageDataContainerName)
+  PYB11_PROPERTY(DataArrayPath CreatedImageDataContainerName READ getCreatedImageDataContainerName WRITE setCreatedImageDataContainerName)
   PYB11_PROPERTY(DataArrayPath ImageDataContainerPath READ getImageDataContainerPath WRITE setImageDataContainerPath)
   PYB11_PROPERTY(DataArrayPath VoxelIndicesArrayPath READ getVoxelIndicesArrayPath WRITE setVoxelIndicesArrayPath)
   PYB11_PROPERTY(IntVec3Type GridDimensions READ getGridDimensions WRITE setGridDimensions)
   PYB11_PROPERTY(bool UseMask READ getUseMask WRITE setUseMask)
-  PYB11_PROPERTY(int CreateDataContainer READ getCreateDataContainer WRITE setCreateDataContainer)
+  PYB11_PROPERTY(int SamplingGridType READ getSamplingGridType WRITE setSamplingGridType)
   PYB11_PROPERTY(DataArrayPath MaskArrayPath READ getMaskArrayPath WRITE setMaskArrayPath)
   PYB11_END_BINDINGS()
+
 public:
   using Self = MapPointCloudToRegularGrid;
   using Pointer = std::shared_ptr<Self>;
@@ -76,15 +77,15 @@ public:
   Q_PROPERTY(DataArrayPath DataContainerName READ getDataContainerName WRITE setDataContainerName)
 
   /**
-   * @brief Setter property for ImageDataContainerName
+   * @brief Setter property for CreatedImageDataContainerName
    */
-  void setImageDataContainerName(const QString& value);
+  void setCreatedImageDataContainerName(const DataArrayPath& value);
   /**
-   * @brief Getter property for ImageDataContainerName
-   * @return Value of ImageDataContainerName
+   * @brief Getter property for CreatedImageDataContainerName
+   * @return Value of CreatedImageDataContainerName
    */
-  QString getImageDataContainerName() const;
-  Q_PROPERTY(QString ImageDataContainerName READ getImageDataContainerName WRITE setImageDataContainerName)
+  DataArrayPath getCreatedImageDataContainerName() const;
+  Q_PROPERTY(DataArrayPath CreatedImageDataContainerName READ getCreatedImageDataContainerName WRITE setCreatedImageDataContainerName)
 
   /**
    * @brief Setter property for ImageDataContainerPath
@@ -131,15 +132,15 @@ public:
   Q_PROPERTY(bool UseMask READ getUseMask WRITE setUseMask)
 
   /**
-   * @brief Setter property for CreateDataContainer
+   * @brief Setter property for SamplingGridType
    */
-  void setCreateDataContainer(int value);
+  void setSamplingGridType(int value);
   /**
-   * @brief Getter property for CreateDataContainer
-   * @return Value of CreateDataContainer
+   * @brief Getter property for SamplingGridType
+   * @return Value of SamplingGridType
    */
-  int getCreateDataContainer() const;
-  Q_PROPERTY(int CreateDataContainer READ getCreateDataContainer WRITE setCreateDataContainer)
+  int getSamplingGridType() const;
+  Q_PROPERTY(int SamplingGridType READ getSamplingGridType WRITE setSamplingGridType)
 
   /**
    * @brief Setter property for MaskArrayPath
@@ -197,11 +198,6 @@ public:
   void setupFilterParameters() override;
 
   /**
-   * @brief readFilterParameters Reimplemented from @see AbstractFilter class
-   */
-  void readFilterParameters(AbstractFilterParametersReader* reader, int index) override;
-
-  /**
    * @brief execute Reimplemented from @see AbstractFilter class
    */
   void execute() override;
@@ -238,12 +234,12 @@ private:
   bool* m_Mask = nullptr;
 
   DataArrayPath m_DataContainerName = {"", "", ""};
-  QString m_ImageDataContainerName = {"ImageDataContainer"};
+  DataArrayPath m_CreatedImageDataContainerName = {"ImageDataContainer", "", ""};
   DataArrayPath m_ImageDataContainerPath = {"", "", ""};
   DataArrayPath m_VoxelIndicesArrayPath = {"", "", "VoxelIndices"};
   IntVec3Type m_GridDimensions = {10, 10, 10};
   bool m_UseMask = {false};
-  int m_CreateDataContainer = {0};
+  int m_SamplingGridType = {0};
   DataArrayPath m_MaskArrayPath = {"", "", ""};
 
   std::vector<float> m_MeshMinExtents;

--- a/DREAM3DReviewFilters/NormalizeArrays.cpp
+++ b/DREAM3DReviewFilters/NormalizeArrays.cpp
@@ -329,8 +329,6 @@ private:
 // -----------------------------------------------------------------------------
 void NormalizeArrays::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/ParaDisReader.cpp
+++ b/DREAM3DReviewFilters/ParaDisReader.cpp
@@ -188,10 +188,11 @@ void ParaDisReader::initialize()
 // -----------------------------------------------------------------------------
 void ParaDisReader::dataCheck()
 {
-  DataArrayPath tempPath;
-
   clearErrorCode();
   clearWarningCode();
+
+  DataArrayPath tempPath;
+
   DataContainer::Pointer m = getDataContainerArray()->createNonPrereqDataContainer(this, getEdgeDataContainerName(), DataContainerID);
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/PointSampleTriangleGeometry.cpp
+++ b/DREAM3DReviewFilters/PointSampleTriangleGeometry.cpp
@@ -358,8 +358,6 @@ void PointSampleTriangleGeometry::sampleTriangle(float a[3], float b[3], float c
 // -----------------------------------------------------------------------------
 void PointSampleTriangleGeometry::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/PottsModel.cpp
+++ b/DREAM3DReviewFilters/PottsModel.cpp
@@ -392,6 +392,8 @@ void PottsModel::setupFilterParameters()
 // -----------------------------------------------------------------------------
 void PottsModel::dataCheck()
 {
+  clearErrorCode();
+  clearWarningCode();
   initialize();
 
   if(getIterations() < 1)

--- a/DREAM3DReviewFilters/PrincipalComponentAnalysis.cpp
+++ b/DREAM3DReviewFilters/PrincipalComponentAnalysis.cpp
@@ -267,8 +267,6 @@ void copyDataArrays(IDataArray::Pointer dataPtr, std::vector<double>& copy, int3
 // -----------------------------------------------------------------------------
 void PrincipalComponentAnalysis::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/ReadBinaryCTNorthStar.cpp
+++ b/DREAM3DReviewFilters/ReadBinaryCTNorthStar.cpp
@@ -552,8 +552,6 @@ int32_t ReadBinaryCTNorthStar::readHeaderMetaData()
 // -----------------------------------------------------------------------------
 void ReadBinaryCTNorthStar::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/ReadMicData.cpp
+++ b/DREAM3DReviewFilters/ReadMicData.cpp
@@ -305,12 +305,13 @@ void ReadMicData::initialize()
 // -----------------------------------------------------------------------------
 void ReadMicData::dataCheck()
 {
+  clearErrorCode();
+  clearWarningCode();
+
   // Reset FileWasRead flag
   m_FileWasRead = false;
 
   DataArrayPath tempPath;
-  clearErrorCode();
-  clearWarningCode();
 
   DataContainer::Pointer m = getDataContainerArray()->createNonPrereqDataContainer(this, getDataContainerName(), DataContainerID);
   if(getErrorCode() < 0)

--- a/DREAM3DReviewFilters/Silhouette.cpp
+++ b/DREAM3DReviewFilters/Silhouette.cpp
@@ -196,8 +196,6 @@ void Silhouette::dataCheck()
 // -----------------------------------------------------------------------------
 void Silhouette::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/SliceTriangleGeometry.cpp
+++ b/DREAM3DReviewFilters/SliceTriangleGeometry.cpp
@@ -282,8 +282,6 @@ void SliceTriangleGeometry::determineBoundsAndNumSlices(float& minDim, float& ma
 // -----------------------------------------------------------------------------
 void SliceTriangleGeometry::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/SteinerCompact.cpp
+++ b/DREAM3DReviewFilters/SteinerCompact.cpp
@@ -172,7 +172,8 @@ void SteinerCompact::initialize()
 // -----------------------------------------------------------------------------
 void SteinerCompact::dataCheck()
 {
-
+  clearErrorCode();
+  clearWarningCode();
   std::vector<size_t> cDims(1, 1);
   QVector<DataArrayPath> dataArrayPaths;
 
@@ -1033,8 +1034,6 @@ void SteinerCompact::output_txt(std::vector<std::vector<float>>& vertices_x, std
 // -----------------------------------------------------------------------------
 void SteinerCompact::execute()
 {
-  clearErrorCode();
-  clearWarningCode();
   dataCheck();
   if(getErrorCode() < 0)
   {

--- a/DREAM3DReviewFilters/TesselateFarFieldGrains.cpp
+++ b/DREAM3DReviewFilters/TesselateFarFieldGrains.cpp
@@ -451,9 +451,9 @@ void TesselateFarFieldGrains::initialize()
 // -----------------------------------------------------------------------------
 void TesselateFarFieldGrains::dataCheck()
 {
-  DataArrayPath tempPath;
   clearErrorCode();
   clearWarningCode();
+  DataArrayPath tempPath;
   // This is for convenience
 
   // Make sure we have our input DataContainer with the proper Ensemble data

--- a/DREAM3DReviewFilters/TiDwellFatigueCrystallographicAnalysis.cpp
+++ b/DREAM3DReviewFilters/TiDwellFatigueCrystallographicAnalysis.cpp
@@ -309,9 +309,9 @@ void TiDwellFatigueCrystallographicAnalysis::initialize()
 // -----------------------------------------------------------------------------
 void TiDwellFatigueCrystallographicAnalysis::dataCheck()
 {
-  DataArrayPath tempPath;
   clearErrorCode();
   clearWarningCode();
+  DataArrayPath tempPath;
 
   DataContainer::Pointer m = getDataContainerArray()->getPrereqDataContainer(this, m_FeatureIdsArrayPath.getDataContainerName(), false);
   if(getErrorCode() < 0 || nullptr == m.get())

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -96,6 +96,7 @@ if(SIMPL_ENABLE_PYTHON)
     "03_Adaptive_Alignment_Mutual_Information_SEM_Images"
     "04_Adaptive_Alignment_Steiner_Compact"
     "InsertTransformationPhase"
+    "ImportQMMeltpoolH5File"
   )
 
   include(${SIMPLProj_SOURCE_DIR}/Wrapping/Python/Binding/CreatePybind11Module.cmake)

--- a/Test/Python/ImportQMMeltpoolH5File.py
+++ b/Test/Python/ImportQMMeltpoolH5File.py
@@ -1,0 +1,116 @@
+# 
+
+# These are the simpl_py python modules
+import os
+import simpl
+import simplpy
+import simpl_helpers as sh
+import simpl_test_dirs as sd
+import dream3dreviewpy
+
+MELTPOOL_DATACONTAINER_NAME = "MeltPool Data"
+VERTEX_ATTRIBUTE_MATRIX_NAME = "Vertex Data"
+LASERTTL_NAME = "LaserTTL"
+MASK_ARRAY_NAME = "Mask"
+VOXEL_INDICES_NAME = "VoxelIndices"
+AREA_ARRAY_NAME = "Area"
+INTENSITY_ARRAY_NAME = "Intensity"
+UNIFORM_INTERPOLATION_TECHNIQUE = 0
+IMAGE_DATA_CONTAINER_NAME = "ImageDataContainer"
+INTERPOLATED_ATTRIBUTE_MATRIX_NAME = "InterpolatedAttributeMatrix"
+
+
+def start_test():
+# Create Data Container Array
+    dca = simpl.DataContainerArray()
+
+    # Import the QM Meltpool HDF5 file
+    print(f'Importing QMMeltpool HDF5 File....')
+    input_files = [sd.GetBuildDirectory() + "/Data/DREAM3DReview/QMMeltPool_Data.h5"]
+    err = dream3dreviewpy.import_qm_meltpool_h5_file(data_container_array=dca, 
+                                                      input_files = input_files, 
+                                                      data_container_path = MELTPOOL_DATACONTAINER_NAME, 
+                                                      vertex_attribute_matrix_name = VERTEX_ATTRIBUTE_MATRIX_NAME, 
+                                                      slice_range = simpl.IntVec2([200,204]), 
+                                                      power = 10)
+    assert err == 0, f'import_qm_meltpool_h5_file: {err}'
+
+    # Threshold Objects
+    # Create the selected thresholds / comparison inputs for MultiThresholdObjects filter
+    print(f'Thresholding Data....')
+    selectedThresholds = simpl.ComparisonInputs()
+    selectedThresholds.addInput(MELTPOOL_DATACONTAINER_NAME, VERTEX_ATTRIBUTE_MATRIX_NAME, LASERTTL_NAME,
+                                simpl.ComparisonOperators.GreaterThan, 0.0)
+    err = simplpy.multi_threshold_objects(dca, MASK_ARRAY_NAME, selectedThresholds)
+    assert err == 0, f'MultiThresholdObjects ErrorCondition: {err}'
+
+    # Map the vertices into a regular grid
+    print(f'Mapping vertices onto a regular grid....')
+    err = dream3dreviewpy.map_point_cloud_to_regular_grid(dca, 
+                                    data_container_name = simpl.DataArrayPath(MELTPOOL_DATACONTAINER_NAME, "", ""), 
+                                    created_image_data_container_name = IMAGE_DATA_CONTAINER_NAME, 
+                                    # image_data_container_path = None, 
+                                    voxel_indices_array_path = simpl.DataArrayPath(MELTPOOL_DATACONTAINER_NAME, VERTEX_ATTRIBUTE_MATRIX_NAME, VOXEL_INDICES_NAME),
+                                    grid_dimensions = simpl.IntVec3([2048, 2048, 5]), 
+                                    use_mask = True,
+                                    sampling_grid_type = 0, 
+                                    mask_array_path = simpl.DataArrayPath(MELTPOOL_DATACONTAINER_NAME, VERTEX_ATTRIBUTE_MATRIX_NAME, MASK_ARRAY_NAME) )
+    assert err == 0, f'map_point_cloud_to_regular_grid ErrorCondition: {err}'
+
+    # Sample the vertices onto the regular grid that was created in the last step
+    print(f'Interpolating Vertex Data....')
+    err = dream3dreviewpy.interpolate_point_cloud_to_regular_grid(dca, 
+                                  data_container_name = MELTPOOL_DATACONTAINER_NAME,
+                                  arrays_to_interpolate = [simpl.DataArrayPath(MELTPOOL_DATACONTAINER_NAME, VERTEX_ATTRIBUTE_MATRIX_NAME, AREA_ARRAY_NAME),
+                                                           simpl.DataArrayPath(MELTPOOL_DATACONTAINER_NAME, VERTEX_ATTRIBUTE_MATRIX_NAME, INTENSITY_ARRAY_NAME)],
+                                  arrays_to_copy = [simpl.DataArrayPath(MELTPOOL_DATACONTAINER_NAME, VERTEX_ATTRIBUTE_MATRIX_NAME, AREA_ARRAY_NAME),
+                                                           simpl.DataArrayPath(MELTPOOL_DATACONTAINER_NAME, VERTEX_ATTRIBUTE_MATRIX_NAME, INTENSITY_ARRAY_NAME)],
+                                  voxel_indices_array_path = simpl.DataArrayPath(MELTPOOL_DATACONTAINER_NAME, VERTEX_ATTRIBUTE_MATRIX_NAME, VOXEL_INDICES_NAME),
+                                  interpolated_data_container_name = IMAGE_DATA_CONTAINER_NAME,
+                                  interpolated_attribute_matrix_name = INTERPOLATED_ATTRIBUTE_MATRIX_NAME,
+                                  interpolation_technique = UNIFORM_INTERPOLATION_TECHNIQUE,
+                                  kernel_size = simpl.FloatVec3([75.0, 75.0, 1.0]),
+                                  sigmas = None,
+                                  use_mask = True,
+                                  mask_array_path = simpl.DataArrayPath(MELTPOOL_DATACONTAINER_NAME, VERTEX_ATTRIBUTE_MATRIX_NAME, MASK_ARRAY_NAME),
+                                  store_kernel_distances = False,
+                                  kernel_distances_array_name = None,
+                                  interpolated_suffix = " [Interpolated]",
+                                  copy_suffix = " [Copied]")
+    assert err == 0, f'interpolate_point_cloud_to_regular_grid ErrorCondition: {err}'
+
+    # Find some scalar statistics on each voxel cell so that we can create an image to export
+    print(f'Finding Statistics for each voxel....')
+    dream3dreviewpy.find_neighbor_list_statistics(dca, 
+                                      find_length = False,
+                                      find_min = False,
+                                      find_max = True, 
+                                      find_mean = True, 
+                                      find_median = True, 
+                                      find_std_deviation = False, 
+                                      find_summation = False, 
+                                      destination_attribute_matrix = simpl.DataArrayPath(IMAGE_DATA_CONTAINER_NAME, INTERPOLATED_ATTRIBUTE_MATRIX_NAME, ""), 
+                                      length_array_name = None, 
+                                      minimum_array_name = None, 
+                                      maximum_array_name = AREA_ARRAY_NAME + " [Maximum]", 
+                                      mean_array_name = AREA_ARRAY_NAME + " [Mean]", 
+                                      median_array_name = AREA_ARRAY_NAME + " [Median]", 
+                                      std_deviation_array_name = None, 
+                                      summation_array_name = None,
+                                      selected_array_path = simpl.DataArrayPath(IMAGE_DATA_CONTAINER_NAME, INTERPOLATED_ATTRIBUTE_MATRIX_NAME, AREA_ARRAY_NAME + " [Interpolated]"))
+
+    # Write to DREAM3D File
+    print(f'Writing DREAM3D file ....')
+    err = simplpy.data_container_writer(dca, sd.GetTestTempDirectory() +
+                                        '/DREAM3DReview/' +
+                                        'QMMeltPool_Data.dream3d',
+                                        True, False)
+    assert err == 0, f'DataContainerWriter ErrorCondition: {err}'
+
+
+
+
+if __name__ == '__main__':
+    print('Starting Test %s ' % os.path.basename(__file__))
+    start_test()
+    print('Ending Test %s ' % os.path.basename(__file__))


### PR DESCRIPTION
Also allows QMMeltPoolImporter to use more than a single HDF5 file.

Also some code cleanups were also applied into this PR.

Related PRs
https://github.com/BlueQuartzSoftware/DREAM3D/pull/966
https://github.com/BlueQuartzSoftware/SIMPLView/pull/71
https://github.com/BlueQuartzSoftware/SIMPL/pull/415