### PR TITLE
MapPointCloudToRegularGrid: use uint64_t for better compatibility

### DIFF
--- a/DREAM3DReviewFilters/MapPointCloudToRegularGrid.cpp
+++ b/DREAM3DReviewFilters/MapPointCloudToRegularGrid.cpp
@@ -182,7 +182,7 @@ void MapPointCloudToRegularGrid::dataCheck()
 
   std::vector<size_t> cDims(1, 1);
 
-  m_VoxelIndicesPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<size_t>>(this, getVoxelIndicesArrayPath(), 0, cDims);
+  m_VoxelIndicesPtr = getDataContainerArray()->createNonPrereqArrayFromPath<UInt64ArrayType>(this, getVoxelIndicesArrayPath(), 0, cDims);
   if(nullptr != m_VoxelIndicesPtr.lock())
   {
     m_VoxelIndices = m_VoxelIndicesPtr.lock()->getPointer(0);

--- a/DREAM3DReviewFilters/MapPointCloudToRegularGrid.h
+++ b/DREAM3DReviewFilters/MapPointCloudToRegularGrid.h
@@ -228,9 +228,9 @@ protected:
   void initialize();
 
 private:
-  std::weak_ptr<DataArray<MeshIndexType>> m_VoxelIndicesPtr;
-  MeshIndexType* m_VoxelIndices = nullptr;
-  std::weak_ptr<DataArray<bool>> m_MaskPtr;
+  std::weak_ptr<UInt64ArrayType> m_VoxelIndicesPtr;
+  uint64_t* m_VoxelIndices = nullptr;
+  std::weak_ptr<BoolArrayType> m_MaskPtr;
   bool* m_Mask = nullptr;
 
   DataArrayPath m_DataContainerName = {"", "", ""};


### PR DESCRIPTION
The issue is trying to load data from a Dream3d file and then running this filter. The data will load as UInt64 instead of size_t (even though it was size_t originally).

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>